### PR TITLE
fix(binding): make EitherEffect variance-safe and opaque

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ pubspec.lock
 # If you don't generate documentation locally you can remove this line.
 doc/api/
 
+# Directory created by `dart test --coverage`.
+coverage/
+
 # Avoid committing generated Javascript files:
 *.dart.js
 *.info.json      # Produced by the --dump-info flag.

--- a/.pubignore
+++ b/.pubignore
@@ -18,6 +18,7 @@ out/
 
 # Repository-only documentation and agent configuration.
 /AGENTS.md
+/CONTEXT.md
 .agents/
 .claude/
 .github/

--- a/.pubignore
+++ b/.pubignore
@@ -2,6 +2,7 @@
 .dart_tool/
 .packages
 build/
+coverage/
 pubspec.lock
 !example/pubspec.lock
 doc/api/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,10 @@ docs/
   function with direct pattern matching, or delegate only to a proven
   covariance-safe primitive. Apply the internal `@covarianceSafe` marker
   only after documenting a type-and-implementation proof or adding widened
-  covariance regression tests. Follow `docs/either-variance-safety.md`.
+  covariance regression tests. Keep the `EitherEffect` carrier final and
+  library-private with a named private constructor; a public typedef forwards
+  an unnamed constructor from its aliased class. Follow
+  `docs/either-variance-safety.md`.
 
 ## Dependencies
 
@@ -116,6 +119,8 @@ dart pub publish --dry-run
 - APIs affected by variance must include regression tests using
   `Left<L, Never>` and `Right<Never, R>` widened to `Either<L, R>`, plus subtype
   widening such as `int` to `num`. Do not use casts to make these tests pass.
+- Changes to `EitherEffect` must retain a consumer compile-fail fixture proving
+  that `EitherEffect<L>()` exposes no constructor outside the library.
 - Keep deprecated alias coverage in `test/deprecated_aliases_test.dart` so one file-level lint ignore covers compatibility calls.
 - Test naming pattern: `group('MethodName', () { test('description', () { ... }); });`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@
   - `flatten` converts `Either<L, Either<L, R>>` to `Either<L, R>`.
   - `merge` extracts the value from `Either<T, T>`.
 
+### Changed
+
+- **Breaking:** `EitherEffect<L>` is now a scope-bound, contravariant binding
+  capability represented by a named record with a generic `bind` function.
+  This preserves `effect.bind(either)`, `either.bind(effect)`, and
+  `eitherFuture.bind(effect)` while making unsafe `EitherEffect` widening a
+  compile-time error.
+- Each `Either.binding` and `Either.futureBinding` invocation now owns an isolated token and
+  revokes its capability when the block settles. Captured capabilities throw a
+  `StateError` when invoked after their scope closes, and nested scopes catch
+  only their own short-circuit.
+
 ### Deprecated
 
 - Existing names remain available as deprecated compatibility aliases:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,11 @@
   This preserves `effect.bind(either)`, `either.bind(effect)`, and
   `eitherFuture.bind(effect)` while making unsafe `EitherEffect` widening a
   compile-time error.
-- Each `Either.binding` and `Either.futureBinding` invocation now owns an isolated token and
-  revokes its capability when the block settles. Captured capabilities throw a
-  `StateError` when invoked after their scope closes, and nested scopes catch
-  only their own short-circuit.
+- Capabilities issued by `Either.binding` and `Either.futureBinding` are
+  revoked when their binding scope completes. Invoking a captured capability
+  afterward throws a `StateError`.
+- Swallowing a binding scope's short-circuit signal and completing normally now
+  throws a `StateError` instead of producing a `Right`.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,11 @@
 ### Changed
 
 - **Breaking:** `EitherEffect<L>` is now a scope-bound, contravariant binding
-  capability represented by a named record with a generic `bind` function.
-  This preserves `effect.bind(either)`, `either.bind(effect)`, and
-  `eitherFuture.bind(effect)` while making unsafe `EitherEffect` widening a
-  compile-time error.
+  capability represented by a branded named record with a generic `bind`
+  function. Its private-typed brand prevents independent construction, while
+  the generic function makes unsafe `EitherEffect` widening a compile-time
+  error. The `effect.bind(either)`, `either.bind(effect)`, and
+  `eitherFuture.bind(effect)` forms remain supported.
 - Capabilities issued by `Either.binding` and `Either.futureBinding` are
   revoked when their binding scope completes. Invoking a captured capability
   afterward throws a `StateError`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,12 @@
 
 ### Changed
 
-- **Breaking:** `EitherEffect<L>` is now a scope-bound, contravariant binding
-  capability represented by a branded named record with a generic `bind`
-  function. Its private-typed brand prevents independent construction, while
-  the generic function makes unsafe `EitherEffect` widening a compile-time
-  error. The `effect.bind(either)`, `either.bind(effect)`, and
-  `eitherFuture.bind(effect)` forms remain supported.
+- Hardened `EitherEffect<L>` as an opaque, contravariant binding capability
+  backed by a library-private final scope and a phantom function type. Unsafe
+  widening and construction outside the library are compile-time errors, while
+  supported binding syntax and behavior remain unchanged. The
+  `effect.bind(either)`, `either.bind(effect)`, and `eitherFuture.bind(effect)`
+  forms remain supported.
 - Capabilities issued by `Either.binding` and `Either.futureBinding` are
   revoked when their binding scope completes. Invoking a captured capability
   afterward throws a `StateError`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,9 @@
   widening and construction outside the library are compile-time errors, while
   supported binding syntax and behavior remain unchanged. The
   `effect.bind(either)`, `either.bind(effect)`, and `eitherFuture.bind(effect)`
-  forms remain supported.
+  forms remain supported. The source-compatibility exception is prefixed
+  imports and selective imports that omit `BindEitherEffectExtension`; keeping
+  `effect.bind(either)` requires importing that extension unprefixed.
 - Capabilities issued by `Either.binding` and `Either.futureBinding` are
   revoked when their binding scope completes. Invoking a captured capability
   afterward throws a `StateError`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -15,8 +15,9 @@ The lifetime of one `Either.binding` or `Either.futureBinding` computation.
 _Avoid_: Global context, coroutine scope
 
 **Binding capability (`EitherEffect`)**:
-Authority supplied by a binding scope to obtain an `Either`'s right value or
-terminate that scope with a left value of the same type.
+Package-issued authority supplied by a binding scope to obtain an `Either`'s
+right value or terminate that scope with a left value of the same type. Its
+record brand is an implementation marker, not part of the domain operation.
 _Avoid_: Context object, effect object, effect system
 
 **Short-circuit**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,8 +16,9 @@ _Avoid_: Global context, coroutine scope
 
 **Binding capability (`EitherEffect`)**:
 Package-issued authority supplied by a binding scope to obtain an `Either`'s
-right value or terminate that scope with a left value of the same type. Its
-record brand is an implementation marker, not part of the domain operation.
+right value or terminate that scope with a left value of the same type. It is
+an opaque reference to the issuing scope; copying it aliases that same scope
+and does not create new binding authority.
 _Avoid_: Context object, effect object, effect system
 
 **Short-circuit**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,25 @@
+# dart_either
+
+This context defines the language used for typed failure and sequential
+short-circuiting in `dart_either`.
+
+## Language
+
+**Either**:
+A value containing either a typed undesired value on the left or a desired
+value on the right.
+_Avoid_: Result, response wrapper
+
+**Binding scope**:
+The lifetime of one `Either.binding` or `Either.futureBinding` computation.
+_Avoid_: Global context, coroutine scope
+
+**Binding capability (`EitherEffect`)**:
+Authority supplied by a binding scope to obtain an `Either`'s right value or
+terminate that scope with a left value of the same type.
+_Avoid_: Context object, effect object, effect system
+
+**Short-circuit**:
+Termination of a binding scope with its first bound left value, without
+evaluating the remaining steps.
+_Avoid_: Exception handling, failure conversion

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Future<Either<String, BuiltList<int>>> parallelTraverse = Either.parTraverseN(
 | [`Future.toEitherFuture`](https://pub.dev/documentation/dart_either/latest/dart_either/ToEitherFutureExtension/toEitherFuture.html)                | Converts a future, catching errors into `Left`       |
 | [`T.left`](https://pub.dev/documentation/dart_either/latest/dart_either/ToEitherObjectExtension/left.html)                                         | Wraps any value as `Left`                            |
 | [`T.right`](https://pub.dev/documentation/dart_either/latest/dart_either/ToEitherObjectExtension/right.html)                                       | Wraps any value as `Right`                           |
-| [`EitherEffect.bind`](https://pub.dev/documentation/dart_either/latest/dart_either/EitherEffect.html)                                              | Extracts `Right` or short-circuits its binding scope |
+| [`EitherEffect.bind`](https://pub.dev/documentation/dart_either/latest/dart_either/BindEitherEffectExtension/bind.html)                            | Extracts `Right` or short-circuits its binding scope |
 | [`Either.bind`](https://pub.dev/documentation/dart_either/latest/dart_either/BindEitherExtension/bind.html)                                        | Binds an `Either` through an `EitherEffect`          |
 | [`EitherEffect.bindFuture`](https://pub.dev/documentation/dart_either/latest/dart_either/BindFutureEitherEffectExtension/bindFuture.html)          | Awaits and binds through an `EitherEffect`           |
 | [`Future<Either>.bind`](https://pub.dev/documentation/dart_either/latest/dart_either/BindEitherFutureExtension/bind.html)                          | Awaits and binds an `Either`                         |
@@ -534,13 +534,13 @@ Either<AsyncError, BuiltList<User>> usersEither = await httpGetAsEither(
 Use `Either.binding` (sync) or `Either.futureBinding` (async) for do-notation style sequential
 computations that short-circuit on the first `Left`.
 
-Their callback receives an `EitherEffect<L>`: a package-issued, branded,
+Their callback receives an `EitherEffect<L>`: a package-issued, opaque,
 scope-bound binding capability. Use it as `effect.bind(either)`,
-`either.bind(effect)`, or `eitherFuture.bind(effect)`. Its `brand` field is an
-implementation marker and must not be read or copied. Each `Either.binding` or
-`Either.futureBinding` invocation owns an isolated scope, ordinary exceptions
-propagate unchanged, and the capability must not be stored or invoked after
-that scope settles.
+`either.bind(effect)`, or `eitherFuture.bind(effect)`. Its construction and
+binding behavior are library-owned; assigning it to another variable only
+aliases the same scope. Each `Either.binding` or `Either.futureBinding`
+invocation owns an isolated scope, ordinary exceptions propagate unchanged,
+and the capability must not be stored or invoked after that scope settles.
 
 ```dart
 // 1) Define a reusable async pipeline with Either.futureBinding

--- a/README.md
+++ b/README.md
@@ -536,17 +536,18 @@ computations that short-circuit on the first `Left`.
 
 Their callback receives an `EitherEffect<L>`: a scope-bound binding capability.
 It can be used as `effect.bind(either)`, `either.bind(effect)`, or
-`eitherFuture.bind(effect)`. Each call to `Either.binding`/`Either.futureBinding` owns an
-isolated scope, ordinary exceptions propagate unchanged, and the capability
-must not be stored or invoked after that scope settles.
+`eitherFuture.bind(effect)`. Each `Either.binding` or `Either.futureBinding`
+invocation owns an isolated scope, ordinary exceptions propagate unchanged,
+and the capability must not be stored or invoked after that scope settles.
 
 ```dart
 // 1) Define a reusable async pipeline with Either.futureBinding
 Future<Either<AsyncError, dynamic>> httpGetAsEither(String uriString) =>
     Either.futureBinding<AsyncError, dynamic>((effect) async {
-      final uri =
-          Either.catchError(toAsyncError, () => Uri.parse(uriString))
-              .bind(effect);
+      final uri = Either.catchError(
+        toAsyncError,
+        () => Uri.parse(uriString),
+      ).bind(effect);
 
       final response = await Either.catchFutureError(
         toAsyncError,
@@ -575,9 +576,9 @@ Either<AsyncError, BuiltList<User>> toUsers(List list) { ... }
 // 2) Compose another flow by binding previous steps
 Either<AsyncError, BuiltList<User>> usersEither = await Either.futureBinding(
   (effect) async {
-    final dynamic json =
-        await httpGetAsEither('https://jsonplaceholder.typicode.com/users')
-            .bind(effect);
+    final dynamic json = await httpGetAsEither(
+      'https://jsonplaceholder.typicode.com/users',
+    ).bind(effect);
     final BuiltList<User> users = toUsers(json as List).bind(effect);
     return users;
   },

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Many projects import entire FP libraries (dartz, fpdart, …) but only use `Eith
 | Documentation        | **Fully documented** — every method/function has doc comments and examples                                                    |
 | Test coverage        | **Fully tested**                                                                                                              |
 | Completeness         | **Most complete** `Either` implementation available for Dart/Flutter                                                          |
-| Monad comprehensions | ✅ Both `sync` and `async`                                                                                                    |
-| Async map / flatMap  | ✅ `thenMapEither`, `thenFlatMapEither`                                                                                       |
+| Monad comprehensions | ✅ Both `sync` and `async`                                                                                                     |
+| Async map / flatMap  | ✅ `thenMapEither`, `thenFlatMapEither`                                                                                        |
 | Bundle size          | Very **lightweight** and **simple** (compare to dartz)                                                                        |
 
 ---
@@ -67,11 +67,11 @@ dart pub get
 
 ## Documentation & Examples
 
-| Resource             | Link                                                               |
-|----------------------|--------------------------------------------------------------------|
-| 📖 API Documentation | https://pub.dev/documentation/dart_either/latest/dart_either/      |
-| 💡 Examples          | https://github.com/hoc081098/dart_either/tree/master/example/lib   |
-| 🐦 Flutter Example   | https://github.com/hoc081098/node-auth-flutter-BLoC-pattern-RxDart |
+| Resource             | Link                                                                                  |
+|----------------------|---------------------------------------------------------------------------------------|
+| 📖 API Documentation | https://pub.dev/documentation/dart_either/latest/dart_either/ |
+| 💡 Examples          | https://github.com/hoc081098/dart_either/tree/master/example/lib                      |
+| 🐦 Flutter Example   | https://github.com/hoc081098/node-auth-flutter-BLoC-pattern-RxDart                    |
 
 ---
 
@@ -410,36 +410,36 @@ Either<String, int> right = 2.right<String>();
 
 ### 2. Operations
 
-| Method                                                                                                                       | Description                                                   |
-|------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|
-| [`isLeft`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/isLeft.html)                                  | Returns `true` if this is a `Left`                            |
-| [`isRight`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/isRight.html)                                | Returns `true` if this is a `Right`                           |
-| [`fold`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/fold.html)                                      | Applies one of two functions based on variant                 |
-| [`foldLeft`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/foldLeft.html)                              | Left fold with an initial value                               |
-| [`swap`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/swap.html)                                      | Swaps `Left` and `Right`                                      |
-| [`onLeft`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/onLeft.html)                                  | Side-effect on `Left`                                         |
-| [`onRight`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/onRight.html)                                | Side-effect on `Right`                                        |
-| [`map`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/map.html)                                        | Transforms the `Right` value                                  |
-| [`mapLeft`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/mapLeft.html)                                | Transforms the `Left` value                                   |
-| [`flatMap`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/flatMap.html)                                | Chains computations                                           |
-| [`bimap`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/bimap.html)                                    | Transforms both sides                                         |
-| [`combine`](https://pub.dev/documentation/dart_either/latest/dart_either/CombineEitherExtension/combine.html)                | Combines two `Either` values                                  |
-| [`isRightAnd`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/isRightAnd.html)                          | Tests the `Right` value with a predicate                      |
-| [`all`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/all.html)                                        | Returns `true` for `Left` or if `Right` matches the predicate |
-| [`getOrDefault`](https://pub.dev/documentation/dart_either/latest/dart_either/GetOrDefaultEitherExtension/getOrDefault.html) | Extracts `Right` or falls back to an eager default value      |
-| [`getOrNull`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/getOrNull.html)                            | Extracts `Right` or returns `null`                            |
-| [`leftOrNull`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/leftOrNull.html)                          | Extracts `Left` or returns `null`                             |
-| [`getOrHandle`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/getOrHandle.html)                        | Extracts `Right` or maps `Left` to a value                    |
-| [`flatten`](https://pub.dev/documentation/dart_either/latest/dart_either/FlattenEitherExtension/flatten.html)                | Flattens nested `Either`                                      |
-| [`merge`](https://pub.dev/documentation/dart_either/latest/dart_either/MergeEitherExtension/merge.html)                      | Extracts value when both sides have same type                 |
-| [`findOrNull`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/findOrNull.html)                          | Finds `Right` matching a predicate                            |
-| [`when`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/when.html)                                      | Pattern-match returning the matched value                     |
-| [`handleErrorWith`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/handleErrorWith.html)                | Recovers from `Left` with a new `Either`                      |
-| [`handleError`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/handleError.html)                        | Recovers from `Left` with a new `Right` value                 |
-| [`redeem`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/redeem.html)                                  | Maps both sides to the same type                              |
-| [`redeemWith`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/redeemWith.html)                          | Maps both sides to a new `Either`                             |
-| [`toFuture`](https://pub.dev/documentation/dart_either/latest/dart_either/AsFutureEitherExtension/toFuture.html)             | Converts to a `Future`                                        |
-| [`getOrThrow`](https://pub.dev/documentation/dart_either/latest/dart_either/GetOrThrowEitherExtension/getOrThrow.html)       | Extracts `Right` or throws the `Left` value                   |
+| Method                                                                                                                 | Description                                   |
+|------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|
+| [`isLeft`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/isLeft.html)                            | Returns `true` if this is a `Left`            |
+| [`isRight`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/isRight.html)                          | Returns `true` if this is a `Right`           |
+| [`fold`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/fold.html)                                | Applies one of two functions based on variant |
+| [`foldLeft`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/foldLeft.html)                        | Left fold with an initial value               |
+| [`swap`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/swap.html)                                | Swaps `Left` and `Right`                      |
+| [`onLeft`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/onLeft.html)                            | Side-effect on `Left`                         |
+| [`onRight`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/onRight.html)                          | Side-effect on `Right`                        |
+| [`map`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/map.html)                                  | Transforms the `Right` value                  |
+| [`mapLeft`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/mapLeft.html)                          | Transforms the `Left` value                   |
+| [`flatMap`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/flatMap.html)                          | Chains computations                           |
+| [`bimap`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/bimap.html)                              | Transforms both sides                         |
+| [`combine`](https://pub.dev/documentation/dart_either/latest/dart_either/CombineEitherExtension/combine.html)         | Combines two `Either` values                  |
+| [`isRightAnd`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/isRightAnd.html)                    | Tests the `Right` value with a predicate      |
+| [`all`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/all.html)                                  | Returns `true` for `Left` or if `Right` matches the predicate |
+| [`getOrDefault`](https://pub.dev/documentation/dart_either/latest/dart_either/GetOrDefaultEitherExtension/getOrDefault.html) | Extracts `Right` or falls back to an eager default value |
+| [`getOrNull`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/getOrNull.html)                      | Extracts `Right` or returns `null`            |
+| [`leftOrNull`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/leftOrNull.html)                    | Extracts `Left` or returns `null`             |
+| [`getOrHandle`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/getOrHandle.html)                  | Extracts `Right` or maps `Left` to a value    |
+| [`flatten`](https://pub.dev/documentation/dart_either/latest/dart_either/FlattenEitherExtension/flatten.html)          | Flattens nested `Either`                      |
+| [`merge`](https://pub.dev/documentation/dart_either/latest/dart_either/MergeEitherExtension/merge.html)                | Extracts value when both sides have same type |
+| [`findOrNull`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/findOrNull.html)                    | Finds `Right` matching a predicate            |
+| [`when`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/when.html)                                | Pattern-match returning the matched value     |
+| [`handleErrorWith`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/handleErrorWith.html)          | Recovers from `Left` with a new `Either`      |
+| [`handleError`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/handleError.html)                  | Recovers from `Left` with a new `Right` value |
+| [`redeem`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/redeem.html)                            | Maps both sides to the same type              |
+| [`redeemWith`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/redeemWith.html)                    | Maps both sides to a new `Either`             |
+| [`toFuture`](https://pub.dev/documentation/dart_either/latest/dart_either/AsFutureEitherExtension/toFuture.html)       | Converts to a `Future`                        |
+| [`getOrThrow`](https://pub.dev/documentation/dart_either/latest/dart_either/GetOrThrowEitherExtension/getOrThrow.html) | Extracts `Right` or throws the `Left` value   |
 
 ```dart
 final ok = Either<String, int>.right(10);
@@ -534,11 +534,13 @@ Either<AsyncError, BuiltList<User>> usersEither = await httpGetAsEither(
 Use `Either.binding` (sync) or `Either.futureBinding` (async) for do-notation style sequential
 computations that short-circuit on the first `Left`.
 
-Their callback receives an `EitherEffect<L>`: a scope-bound binding capability.
-It can be used as `effect.bind(either)`, `either.bind(effect)`, or
-`eitherFuture.bind(effect)`. Each `Either.binding` or `Either.futureBinding`
-invocation owns an isolated scope, ordinary exceptions propagate unchanged,
-and the capability must not be stored or invoked after that scope settles.
+Their callback receives an `EitherEffect<L>`: a package-issued, branded,
+scope-bound binding capability. Use it as `effect.bind(either)`,
+`either.bind(effect)`, or `eitherFuture.bind(effect)`. Its `brand` field is an
+implementation marker and must not be read or copied. Each `Either.binding` or
+`Either.futureBinding` invocation owns an isolated scope, ordinary exceptions
+propagate unchanged, and the capability must not be stored or invoked after
+that scope settles.
 
 ```dart
 // 1) Define a reusable async pipeline with Either.futureBinding

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Many projects import entire FP libraries (dartz, fpdart, …) but only use `Eith
 | Documentation        | **Fully documented** — every method/function has doc comments and examples                                                    |
 | Test coverage        | **Fully tested**                                                                                                              |
 | Completeness         | **Most complete** `Either` implementation available for Dart/Flutter                                                          |
-| Monad comprehensions | ✅ Both `sync` and `async`                                                                                                     |
-| Async map / flatMap  | ✅ `thenMapEither`, `thenFlatMapEither`                                                                                        |
+| Monad comprehensions | ✅ Both `sync` and `async`                                                                                                    |
+| Async map / flatMap  | ✅ `thenMapEither`, `thenFlatMapEither`                                                                                       |
 | Bundle size          | Very **lightweight** and **simple** (compare to dartz)                                                                        |
 
 ---
@@ -67,11 +67,11 @@ dart pub get
 
 ## Documentation & Examples
 
-| Resource             | Link                                                                                  |
-|----------------------|---------------------------------------------------------------------------------------|
-| 📖 API Documentation | https://pub.dev/documentation/dart_either/latest/dart_either/ |
-| 💡 Examples          | https://github.com/hoc081098/dart_either/tree/master/example/lib                      |
-| 🐦 Flutter Example   | https://github.com/hoc081098/node-auth-flutter-BLoC-pattern-RxDart                    |
+| Resource             | Link                                                               |
+|----------------------|--------------------------------------------------------------------|
+| 📖 API Documentation | https://pub.dev/documentation/dart_either/latest/dart_either/      |
+| 💡 Examples          | https://github.com/hoc081098/dart_either/tree/master/example/lib   |
+| 🐦 Flutter Example   | https://github.com/hoc081098/node-auth-flutter-BLoC-pattern-RxDart |
 
 ---
 
@@ -228,9 +228,9 @@ final right = Either<Object, int>.right(1);
 // or: Right<Object, int>(1)
 
 // 2) Sync monad comprehension (short-circuits on first Left)
-Either<Object, String>.binding((e) {
-  final String s = left.bind(e);
-  final int i = right.bind(e);
+Either<Object, String>.binding((effect) {
+  final String s = left.bind(effect);
+  final int i = right.bind(effect);
   return '$s $i';
 });
 
@@ -294,19 +294,19 @@ Either.fromNullable<int>(1);    // Right(1)
 // 4) Either.futureBinding
 String url1 = 'url1';
 String url2 = 'url2';
-Either.futureBinding<String, http.Response>((e) async {
+Either.futureBinding<String, http.Response>((effect) async {
   final response = await Either.catchFutureError(
     (e, s) => 'Get $url1: $e',
     () async {
       final uri = Uri.parse(url1);
       return http.get(uri);
     },
-  ).bind(e);
+  ).bind(effect);
 
   final id = Either.catchError(
     (e, s) => 'Parse $url1 body: $e',
     () => jsonDecode(response.body)['id'] as String,
-  ).bind(e);
+  ).bind(effect);
 
   return await Either.catchFutureError(
     (e, s) => 'Get $url2: $e',
@@ -314,7 +314,7 @@ Either.futureBinding<String, http.Response>((e) async {
       final uri = Uri.parse('$url2?id=$id');
       return http.get(uri);
     },
-  ).bind(e);
+  ).bind(effect);
 });
 
 
@@ -364,14 +364,20 @@ Future<Either<String, BuiltList<int>>> parallelTraverse = Either.parTraverseN(
 );
 ```
 
-#### 1.3. Extension methods
+#### 1.3. Binding capability and extension methods
 
-| Extension                                                                                                                           | Description                                    |
-|-------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------|
-| [`Stream.toEitherStream`](https://pub.dev/documentation/dart_either/latest/dart_either/ToEitherStreamExtension/toEitherStream.html) | Converts a stream, catching errors into `Left` |
-| [`Future.toEitherFuture`](https://pub.dev/documentation/dart_either/latest/dart_either/ToEitherFutureExtension/toEitherFuture.html) | Converts a future, catching errors into `Left` |
-| [`T.left`](https://pub.dev/documentation/dart_either/latest/dart_either/ToEitherObjectExtension/left.html)                          | Wraps any value as `Left`                      |
-| [`T.right`](https://pub.dev/documentation/dart_either/latest/dart_either/ToEitherObjectExtension/right.html)                        | Wraps any value as `Right`                     |
+| API                                                                                                                                                | Description                                          |
+|----------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
+| [`Stream.toEitherStream`](https://pub.dev/documentation/dart_either/latest/dart_either/ToEitherStreamExtension/toEitherStream.html)                | Converts a stream, catching errors into `Left`       |
+| [`Future.toEitherFuture`](https://pub.dev/documentation/dart_either/latest/dart_either/ToEitherFutureExtension/toEitherFuture.html)                | Converts a future, catching errors into `Left`       |
+| [`T.left`](https://pub.dev/documentation/dart_either/latest/dart_either/ToEitherObjectExtension/left.html)                                         | Wraps any value as `Left`                            |
+| [`T.right`](https://pub.dev/documentation/dart_either/latest/dart_either/ToEitherObjectExtension/right.html)                                       | Wraps any value as `Right`                           |
+| [`EitherEffect.bind`](https://pub.dev/documentation/dart_either/latest/dart_either/EitherEffect.html)                                              | Extracts `Right` or short-circuits its binding scope |
+| [`Either.bind`](https://pub.dev/documentation/dart_either/latest/dart_either/BindEitherExtension/bind.html)                                        | Binds an `Either` through an `EitherEffect`          |
+| [`EitherEffect.bindFuture`](https://pub.dev/documentation/dart_either/latest/dart_either/BindFutureEitherEffectExtension/bindFuture.html)          | Awaits and binds through an `EitherEffect`           |
+| [`Future<Either>.bind`](https://pub.dev/documentation/dart_either/latest/dart_either/BindEitherFutureExtension/bind.html)                          | Awaits and binds an `Either`                         |
+| [`EitherEffect.ensure`](https://pub.dev/documentation/dart_either/latest/dart_either/EnsureEitherEffectExtension/ensure.html)                      | Short-circuits when a condition is false             |
+| [`EitherEffect.ensureNotNull`](https://pub.dev/documentation/dart_either/latest/dart_either/EnsureNotNullEitherEffectExtension/ensureNotNull.html) | Extracts a non-null value or short-circuits          |
 
 ```dart
 // 1) Stream.toEitherStream
@@ -404,36 +410,36 @@ Either<String, int> right = 2.right<String>();
 
 ### 2. Operations
 
-| Method                                                                                                                 | Description                                   |
-|------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|
-| [`isLeft`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/isLeft.html)                            | Returns `true` if this is a `Left`            |
-| [`isRight`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/isRight.html)                          | Returns `true` if this is a `Right`           |
-| [`fold`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/fold.html)                                | Applies one of two functions based on variant |
-| [`foldLeft`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/foldLeft.html)                        | Left fold with an initial value               |
-| [`swap`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/swap.html)                                | Swaps `Left` and `Right`                      |
-| [`onLeft`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/onLeft.html)                            | Side-effect on `Left`                         |
-| [`onRight`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/onRight.html)                          | Side-effect on `Right`                        |
-| [`map`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/map.html)                                  | Transforms the `Right` value                  |
-| [`mapLeft`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/mapLeft.html)                          | Transforms the `Left` value                   |
-| [`flatMap`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/flatMap.html)                          | Chains computations                           |
-| [`bimap`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/bimap.html)                              | Transforms both sides                         |
-| [`combine`](https://pub.dev/documentation/dart_either/latest/dart_either/CombineEitherExtension/combine.html)         | Combines two `Either` values                  |
-| [`isRightAnd`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/isRightAnd.html)                    | Tests the `Right` value with a predicate      |
-| [`all`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/all.html)                                  | Returns `true` for `Left` or if `Right` matches the predicate |
-| [`getOrDefault`](https://pub.dev/documentation/dart_either/latest/dart_either/GetOrDefaultEitherExtension/getOrDefault.html) | Extracts `Right` or falls back to an eager default value |
-| [`getOrNull`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/getOrNull.html)                      | Extracts `Right` or returns `null`            |
-| [`leftOrNull`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/leftOrNull.html)                    | Extracts `Left` or returns `null`             |
-| [`getOrHandle`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/getOrHandle.html)                  | Extracts `Right` or maps `Left` to a value    |
-| [`flatten`](https://pub.dev/documentation/dart_either/latest/dart_either/FlattenEitherExtension/flatten.html)          | Flattens nested `Either`                      |
-| [`merge`](https://pub.dev/documentation/dart_either/latest/dart_either/MergeEitherExtension/merge.html)                | Extracts value when both sides have same type |
-| [`findOrNull`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/findOrNull.html)                    | Finds `Right` matching a predicate            |
-| [`when`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/when.html)                                | Pattern-match returning the matched value     |
-| [`handleErrorWith`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/handleErrorWith.html)          | Recovers from `Left` with a new `Either`      |
-| [`handleError`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/handleError.html)                  | Recovers from `Left` with a new `Right` value |
-| [`redeem`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/redeem.html)                            | Maps both sides to the same type              |
-| [`redeemWith`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/redeemWith.html)                    | Maps both sides to a new `Either`             |
-| [`toFuture`](https://pub.dev/documentation/dart_either/latest/dart_either/AsFutureEitherExtension/toFuture.html)       | Converts to a `Future`                        |
-| [`getOrThrow`](https://pub.dev/documentation/dart_either/latest/dart_either/GetOrThrowEitherExtension/getOrThrow.html) | Extracts `Right` or throws the `Left` value   |
+| Method                                                                                                                       | Description                                                   |
+|------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|
+| [`isLeft`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/isLeft.html)                                  | Returns `true` if this is a `Left`                            |
+| [`isRight`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/isRight.html)                                | Returns `true` if this is a `Right`                           |
+| [`fold`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/fold.html)                                      | Applies one of two functions based on variant                 |
+| [`foldLeft`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/foldLeft.html)                              | Left fold with an initial value                               |
+| [`swap`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/swap.html)                                      | Swaps `Left` and `Right`                                      |
+| [`onLeft`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/onLeft.html)                                  | Side-effect on `Left`                                         |
+| [`onRight`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/onRight.html)                                | Side-effect on `Right`                                        |
+| [`map`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/map.html)                                        | Transforms the `Right` value                                  |
+| [`mapLeft`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/mapLeft.html)                                | Transforms the `Left` value                                   |
+| [`flatMap`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/flatMap.html)                                | Chains computations                                           |
+| [`bimap`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/bimap.html)                                    | Transforms both sides                                         |
+| [`combine`](https://pub.dev/documentation/dart_either/latest/dart_either/CombineEitherExtension/combine.html)                | Combines two `Either` values                                  |
+| [`isRightAnd`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/isRightAnd.html)                          | Tests the `Right` value with a predicate                      |
+| [`all`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/all.html)                                        | Returns `true` for `Left` or if `Right` matches the predicate |
+| [`getOrDefault`](https://pub.dev/documentation/dart_either/latest/dart_either/GetOrDefaultEitherExtension/getOrDefault.html) | Extracts `Right` or falls back to an eager default value      |
+| [`getOrNull`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/getOrNull.html)                            | Extracts `Right` or returns `null`                            |
+| [`leftOrNull`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/leftOrNull.html)                          | Extracts `Left` or returns `null`                             |
+| [`getOrHandle`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/getOrHandle.html)                        | Extracts `Right` or maps `Left` to a value                    |
+| [`flatten`](https://pub.dev/documentation/dart_either/latest/dart_either/FlattenEitherExtension/flatten.html)                | Flattens nested `Either`                                      |
+| [`merge`](https://pub.dev/documentation/dart_either/latest/dart_either/MergeEitherExtension/merge.html)                      | Extracts value when both sides have same type                 |
+| [`findOrNull`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/findOrNull.html)                          | Finds `Right` matching a predicate                            |
+| [`when`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/when.html)                                      | Pattern-match returning the matched value                     |
+| [`handleErrorWith`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/handleErrorWith.html)                | Recovers from `Left` with a new `Either`                      |
+| [`handleError`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/handleError.html)                        | Recovers from `Left` with a new `Right` value                 |
+| [`redeem`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/redeem.html)                                  | Maps both sides to the same type                              |
+| [`redeemWith`](https://pub.dev/documentation/dart_either/latest/dart_either/Either/redeemWith.html)                          | Maps both sides to a new `Either`                             |
+| [`toFuture`](https://pub.dev/documentation/dart_either/latest/dart_either/AsFutureEitherExtension/toFuture.html)             | Converts to a `Future`                                        |
+| [`getOrThrow`](https://pub.dev/documentation/dart_either/latest/dart_either/GetOrThrowEitherExtension/getOrThrow.html)       | Extracts `Right` or throws the `Left` value                   |
 
 ```dart
 final ok = Either<String, int>.right(10);
@@ -528,19 +534,26 @@ Either<AsyncError, BuiltList<User>> usersEither = await httpGetAsEither(
 Use `Either.binding` (sync) or `Either.futureBinding` (async) for do-notation style sequential
 computations that short-circuit on the first `Left`.
 
+Their callback receives an `EitherEffect<L>`: a scope-bound binding capability.
+It can be used as `effect.bind(either)`, `either.bind(effect)`, or
+`eitherFuture.bind(effect)`. Each call to `Either.binding`/`Either.futureBinding` owns an
+isolated scope, ordinary exceptions propagate unchanged, and the capability
+must not be stored or invoked after that scope settles.
+
 ```dart
 // 1) Define a reusable async pipeline with Either.futureBinding
 Future<Either<AsyncError, dynamic>> httpGetAsEither(String uriString) =>
-    Either.futureBinding<AsyncError, dynamic>((e) async {
+    Either.futureBinding<AsyncError, dynamic>((effect) async {
       final uri =
-          Either.catchError(toAsyncError, () => Uri.parse(uriString)).bind(e);
+          Either.catchError(toAsyncError, () => Uri.parse(uriString))
+              .bind(effect);
 
       final response = await Either.catchFutureError(
         toAsyncError,
         () => http.get(uri),
-      ).bind(e);
+      ).bind(effect);
 
-      e.ensure(
+      effect.ensure(
         response.statusCode >= 200 && response.statusCode < 300,
         () => AsyncError(
           HttpException(
@@ -554,18 +567,18 @@ Future<Either<AsyncError, dynamic>> httpGetAsEither(String uriString) =>
       return Either<AsyncError, dynamic>.catchError(
         toAsyncError,
         () => jsonDecode(response.body),
-      ).bind(e);
+      ).bind(effect);
     });
 
 Either<AsyncError, BuiltList<User>> toUsers(List list) { ... }
 
 // 2) Compose another flow by binding previous steps
 Either<AsyncError, BuiltList<User>> usersEither = await Either.futureBinding(
-  (e) async {
+  (effect) async {
     final dynamic json =
         await httpGetAsEither('https://jsonplaceholder.typicode.com/users')
-            .bind(e);
-    final BuiltList<User> users = toUsers(json as List).bind(e);
+            .bind(effect);
+    final BuiltList<User> users = toUsers(json as List).bind(effect);
     return users;
   },
 );

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,8 +1,9 @@
 include: package:lints/recommended.yaml
 analyzer:
-  strong-mode:
-    implicit-casts: false
-    implicit-dynamic: false
+  language:
+    strict-casts: true
+    strict-raw-types: true
+    strict-inference: true
 linter:
   rules:
     - public_member_api_docs

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ from the published package through `.pubignore`.
 - [Either variance safety](either-variance-safety.md): signature variance,
   instance-method runtime checks, extension design, and widened-type tests.
 - [ADR 0001](adr/0001-scope-bound-contravariant-either-effect.md): why
-  `EitherEffect` is a scope-bound, contravariant record capability.
+  `EitherEffect` is a branded, scope-bound, contravariant record capability.
 - [API rename workflow](../.agents/skills/api-rename-flow/SKILL.md): the required
   process for non-breaking public API renames.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,8 @@ from the published package through `.pubignore`.
 - [Either variance safety](either-variance-safety.md): signature variance,
   instance-method runtime checks, extension design, and widened-type tests.
 - [ADR 0001](adr/0001-scope-bound-contravariant-either-effect.md): why
-  `EitherEffect` is a branded, scope-bound, contravariant record capability.
+  `EitherEffect` is an opaque, scope-bound, contravariant capability backed by
+  a private binding scope.
 - [API rename workflow](../.agents/skills/api-rename-flow/SKILL.md): the required
   process for non-breaking public API renames.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,12 +5,16 @@ workflows. The public API documentation remains in Dart doc comments and the
 root [README](../README.md). This directory is repository-only and excluded
 from the published package through `.pubignore`.
 
+- [Domain language](../CONTEXT.md): canonical terms for binding scopes,
+  binding capabilities, and short-circuiting.
 - [API naming alignment](api-naming-alignment.md): implemented migrations,
   compatibility decisions, the major-version roadmap, and deferred proposals.
 - [Arrow Either reference](arrow-either-reference.md): upstream links and the
   boundary between Arrow inspiration and the Dart implementation.
 - [Either variance safety](either-variance-safety.md): signature variance,
   instance-method runtime checks, extension design, and widened-type tests.
+- [ADR 0001](adr/0001-scope-bound-contravariant-either-effect.md): why
+  `EitherEffect` is a scope-bound, contravariant record capability.
 - [API rename workflow](../.agents/skills/api-rename-flow/SKILL.md): the required
   process for non-breaking public API renames.
 

--- a/docs/adr/0001-scope-bound-contravariant-either-effect.md
+++ b/docs/adr/0001-scope-bound-contravariant-either-effect.md
@@ -35,6 +35,10 @@ the same source shape and behavior: obtain an effect from `Either.binding` or
 `Either.futureBinding`, then use `effect.bind(either)`, `either.bind(effect)`,
 or `eitherFuture.bind(effect)` within the owning scope.
 
+The source-compatibility exception is prefixed imports and selective imports
+that omit `BindEitherEffectExtension`; keeping `effect.bind(either)` requires
+importing that extension unprefixed.
+
 Directly constructing, implementing, destructuring, or replacing the binding
 behavior of `EitherEffect` was never part of the supported contract. Capturing
 an effect and invoking it after its scope settles is also unsupported. Those

--- a/docs/adr/0001-scope-bound-contravariant-either-effect.md
+++ b/docs/adr/0001-scope-bound-contravariant-either-effect.md
@@ -4,13 +4,15 @@ status: accepted
 
 # Represent EitherEffect as a scope-bound contravariant capability
 
-`EitherEffect<L>` is a one-field named record containing a generic `bind`
-function. This shape makes `L` contravariant, so Dart rejects the unsafe
-`EitherEffect<int>` to `EitherEffect<num>` widening that a nominal generic
-class permits, while the named field keeps `effect.bind(...)` discoverable in
-IDE completion. Token identity isolates nested scopes, and each capability
-issued by `binding` or `futureBinding` is revoked when its synchronous or
-asynchronous block settles.
+`EitherEffect<L>` is a branded named record containing a generic `bind`
+function and a private-typed `brand` marker. The generic function makes `L`
+contravariant, so Dart rejects the unsafe `EitherEffect<int>` to
+`EitherEffect<num>` widening that a nominal generic class permits. The named
+`bind` field keeps `effect.bind(...)` discoverable in IDE completion, while the
+brand prevents code that has never received a package-issued marker from
+independently constructing a matching record. Token identity isolates nested
+scopes, and each capability issued by `binding` or `futureBinding` is revoked
+when its synchronous or asynchronous block settles.
 
 ## Considered options
 
@@ -19,6 +21,8 @@ asynchronous block settles.
   fail at runtime before the method body executes.
 - A generic function typedef was type-safe, but Dart completion did not offer
   its extension members after `effect.`.
+- An unbranded named record preserved completion and variance safety, but any
+  caller could construct one with arbitrary `bind` behavior.
 - An extension type around the function was rejected because Dart forbids its
   type parameter in a non-covariant representation position.
 
@@ -31,8 +35,12 @@ asynchronous block settles.
   function invocation is not supported.
 - Capturing the capability is syntactically possible, but invoking it after
   its scope closes throws `StateError`.
-- The typedef is structural, so callers can construct matching records.
-  Scope isolation and revocation are guarantees of capabilities issued by
-  `binding` and `futureBinding`, not of arbitrary user-created records.
+- The private brand type prevents independent record construction. Dart record
+  field names cannot be private, however, so code already holding an issued
+  capability can read and copy its `brand` marker. The brand is a type-level
+  construction barrier, not a runtime authenticity check. Callers must treat
+  it as an implementation detail; scope isolation and revocation are
+  guarantees only of the original capabilities supplied by `binding` and
+  `futureBinding`.
 - The record envelope can add one allocation per binding scope; optimizer
   elimination is not part of the interface contract.

--- a/docs/adr/0001-scope-bound-contravariant-either-effect.md
+++ b/docs/adr/0001-scope-bound-contravariant-either-effect.md
@@ -2,45 +2,74 @@
 status: accepted
 ---
 
-# Represent EitherEffect as a scope-bound contravariant capability
+# Represent EitherEffect with a private scope and contravariant phantom marker
 
-`EitherEffect<L>` is a branded named record containing a generic `bind`
-function and a private-typed `brand` marker. The generic function makes `L`
-contravariant, so Dart rejects the unsafe `EitherEffect<int>` to
-`EitherEffect<num>` widening that a nominal generic class permits. The named
-`bind` field keeps `effect.bind(...)` discoverable in IDE completion, while the
-brand prevents code that has never received a package-issued marker from
-independently constructing a matching record. Token identity isolates nested
-scopes, and each capability issued by `binding` or `futureBinding` is revoked
-when its synchronous or asynchronous block settles.
+`EitherEffect<L>` is an alias to a library-private final binding scope whose
+type argument is a phantom function type:
+
+```dart
+typedef EitherEffect<L> = _BindingScope<Never Function(L)>;
+```
+
+`_BindingScope<T>` is covariant in `T`, while `Never Function(L)` is
+contravariant in `L`. Their composition makes `EitherEffect<L>` contravariant,
+so Dart rejects the unsafe `EitherEffect<int>` to `EitherEffect<num>` widening.
+The phantom type has no runtime value; the private scope itself owns the token,
+lifecycle phase, and direct `Left`/`Right` binding implementation.
+
+`BindEitherEffectExtension.bind` is declared in the same Dart library as the
+scope and delegates to its private generic bind operation. This preserves
+`effect.bind(either)` completion without exposing replaceable behavior. The
+scope is final and has only a named private constructor. The constructor shape
+is an invariant of this decision because a public typedef would forward an
+unnamed constructor from its aliased class.
+
+Token identity continues to isolate nested scopes. Each capability issued by
+`binding` or `futureBinding` is closed when its synchronous or asynchronous
+block settles.
+
+## Compatibility boundary
+
+This representation hardening targets a `2.x.y` release. Supported usage keeps
+the same source shape and behavior: obtain an effect from `Either.binding` or
+`Either.futureBinding`, then use `effect.bind(either)`, `either.bind(effect)`,
+or `eitherFuture.bind(effect)` within the owning scope.
+
+Directly constructing, implementing, destructuring, or replacing the binding
+behavior of `EitherEffect` was never part of the supported contract. Capturing
+an effect and invoking it after its scope settles is also unsupported. Those
+usages do not require compatibility aliases or a major-version migration.
 
 ## Considered options
 
-- A nominal `EitherEffect<L>` with a consuming `bind` method was rejected
-  because Dart class type parameters are covariant and the widened receiver can
-  fail at runtime before the method body executes.
+- A nominal public `EitherEffect<L>` with a consuming instance method was
+  rejected because Dart class type parameters are covariant. A widened
+  receiver can fail its runtime argument check before `bind` executes.
 - A generic function typedef was type-safe, but Dart completion did not offer
   its extension members after `effect.`.
-- An unbranded named record preserved completion and variance safety, but any
-  caller could construct one with arbitrary `bind` behavior.
-- An extension type around the function was rejected because Dart forbids its
-  type parameter in a non-covariant representation position.
+- An unbranded record preserved completion and variance safety, but any caller
+  could construct it with arbitrary binding behavior.
+- A branded record prevented construction from nothing, but a caller holding
+  an issued capability could copy its public brand and replace the public
+  `bind` function.
+- An authenticated brand-and-token record could reject replacement at runtime,
+  but required structural fields, identity checks, and extra per-scope values.
+- An extension type around a contravariant function was rejected because Dart
+  requires its representation type parameter to occur covariantly.
 
 ## Consequences
 
 - Safe narrowing, such as `EitherEffect<num>` to `EitherEffect<int>`, remains
   valid; unsafe widening is a compile-time error.
-- `effect.bind(either)`, `either.bind(effect)`, and
-  `eitherFuture.bind(effect)` remain the supported binding forms. Direct
-  function invocation is not supported.
-- Capturing the capability is syntactically possible, but invoking it after
-  its scope closes throws `StateError`.
-- The private brand type prevents independent record construction. Dart record
-  field names cannot be private, however, so code already holding an issued
-  capability can read and copy its `brand` marker. The brand is a type-level
-  construction barrier, not a runtime authenticity check. Callers must treat
-  it as an implementation detail; scope isolation and revocation are
-  guarantees only of the original capabilities supplied by `binding` and
-  `futureBinding`.
-- The record envelope can add one allocation per binding scope; optimizer
-  elimination is not part of the interface contract.
+- Code outside the declaring library cannot construct, extend, implement, or
+  replace the binding behavior of `EitherEffect`.
+- Copying an issued capability copies the same scope reference. The copy shares
+  its token and lifecycle and cannot create independent binding authority.
+- Capturing the capability is syntactically possible, but invoking it after its
+  scope closes throws `StateError`.
+- The scope object is the capability. The design does not require a record
+  envelope, generic bind closure, global registry, or runtime authenticity
+  lookup.
+- Dartdoc displays the private alias expansion
+  `_BindingScope<Never Function(L)>`; this is an accepted documentation leak of
+  an inaccessible implementation type.

--- a/docs/adr/0001-scope-bound-contravariant-either-effect.md
+++ b/docs/adr/0001-scope-bound-contravariant-either-effect.md
@@ -1,0 +1,38 @@
+---
+status: accepted
+---
+
+# Represent EitherEffect as a scope-bound contravariant capability
+
+`EitherEffect<L>` is a one-field named record containing a generic `bind`
+function. This shape makes `L` contravariant, so Dart rejects the unsafe
+`EitherEffect<int>` to `EitherEffect<num>` widening that a nominal generic
+class permits, while the named field keeps `effect.bind(...)` discoverable in
+IDE completion. Token identity isolates nested scopes, and each capability
+issued by `binding` or `futureBinding` is revoked when its synchronous or
+asynchronous block settles.
+
+## Considered options
+
+- A nominal `EitherEffect<L>` with a consuming `bind` method was rejected
+  because Dart class type parameters are covariant and the widened receiver can
+  fail at runtime before the method body executes.
+- A generic function typedef was type-safe, but Dart completion did not offer
+  its extension members after `effect.`.
+- An extension type around the function was rejected because Dart forbids its
+  type parameter in a non-covariant representation position.
+
+## Consequences
+
+- Safe narrowing, such as `EitherEffect<num>` to `EitherEffect<int>`, remains
+  valid; unsafe widening is a compile-time error.
+- `effect.bind(either)`, `either.bind(effect)`, and
+  `eitherFuture.bind(effect)` remain the supported binding forms. Direct
+  function invocation is not supported.
+- Capturing the capability is syntactically possible, but invoking it after
+  its scope closes throws `StateError`.
+- The typedef is structural, so callers can construct matching records.
+  Scope isolation and revocation are guarantees of capabilities issued by
+  `binding` and `futureBinding`, not of arbitrary user-created records.
+- The record envelope can add one allocation per binding scope; optimizer
+  elimination is not part of the interface contract.

--- a/docs/api-naming-alignment.md
+++ b/docs/api-naming-alignment.md
@@ -33,10 +33,13 @@ The internal `EitherEffect<L>` representation hardening recorded in
 [ADR 0001](adr/0001-scope-bound-contravariant-either-effect.md) targets a
 `2.x.y` release. Supported source usage and runtime behavior remain unchanged:
 callers receive the capability from `Either.binding` or `Either.futureBinding`
-and use the existing binding extensions within that scope. Constructing,
-implementing, destructuring, replacing the binding behavior of, or invoking a
-captured `EitherEffect` after its scope settles is outside the supported
-contract and does not require a compatibility migration.
+and use the existing binding extensions within that scope. The
+source-compatibility exception is prefixed imports and selective imports that
+omit `BindEitherEffectExtension`; keeping `effect.bind(either)` requires
+importing that extension unprefixed. Constructing, implementing, destructuring,
+replacing the binding behavior of, or invoking a captured `EitherEffect` after
+its scope settles is outside the supported contract and does not require a
+compatibility migration.
 
 ## Planned major-version cleanup
 

--- a/docs/api-naming-alignment.md
+++ b/docs/api-naming-alignment.md
@@ -27,14 +27,16 @@ instance member. This preserves the same call syntax while avoiding a runtime
 type check against a covariantly widened receiver. See
 [Either variance safety](either-variance-safety.md).
 
-## Major-release coordination
+## `EitherEffect` 2.x compatibility boundary
 
-The `EitherEffect<L>` redesign recorded in
-[ADR 0001](adr/0001-scope-bound-contravariant-either-effect.md) changes a public
-type and must ship in the next major release, not as a `2.x` update. While the
-work is listed under `Unreleased`, `pubspec.yaml` can retain the current
-published version; the release-preparation commit must assign the new major
-version before publishing.
+The internal `EitherEffect<L>` representation hardening recorded in
+[ADR 0001](adr/0001-scope-bound-contravariant-either-effect.md) targets a
+`2.x.y` release. Supported source usage and runtime behavior remain unchanged:
+callers receive the capability from `Either.binding` or `Either.futureBinding`
+and use the existing binding extensions within that scope. Constructing,
+implementing, destructuring, replacing the binding behavior of, or invoking a
+captured `EitherEffect` after its scope settles is outside the supported
+contract and does not require a compatibility migration.
 
 ## Planned major-version cleanup
 

--- a/docs/api-naming-alignment.md
+++ b/docs/api-naming-alignment.md
@@ -27,6 +27,15 @@ instance member. This preserves the same call syntax while avoiding a runtime
 type check against a covariantly widened receiver. See
 [Either variance safety](either-variance-safety.md).
 
+## Major-release coordination
+
+The `EitherEffect<L>` redesign recorded in
+[ADR 0001](adr/0001-scope-bound-contravariant-either-effect.md) changes a public
+type and must ship in the next major release, not as a `2.x` update. While the
+work is listed under `Unreleased`, `pubspec.yaml` can retain the current
+published version; the release-preparation commit must assign the new major
+version before publishing.
+
 ## Planned major-version cleanup
 
 `getOrHandle` is a compatibility bridge rather than the preferred final name.

--- a/docs/either-variance-safety.md
+++ b/docs/either-variance-safety.md
@@ -178,6 +178,47 @@ the other.
 "Unsafe" here means unsafe as a virtual instance-member boundary for a
 covariantly widened receiver. It does not mean the operation itself is invalid.
 
+## `EitherEffect` must be contravariant
+
+Binding consumes an `Either<L, R>`, so a nominal `EitherEffect<L>` class with
+an instance `bind` method is unsafe when Dart widens its covariant `L`. The
+binding capability instead uses a named record containing a generic function:
+
+```dart
+typedef EitherEffect<L> = ({
+  R Function<R>(Either<L, R> either) bind,
+});
+```
+
+The path to `L` has one sign flip:
+
+```text
+record field type:                 +
+bind function parameter:           -
+Either is covariant in L:          +
+                                    + x - x + = -
+```
+
+`EitherEffect` is therefore contravariant in `L`. An effect that accepts every
+`num` left value can safely be narrowed to one used only with `int`; the
+opposite assignment is rejected:
+
+```dart
+void demonstrate(
+  EitherEffect<num> numbers,
+  EitherEffect<int> onlyIntegers,
+) {
+  final EitherEffect<int> integers = numbers; // Safe.
+  final EitherEffect<num> unsafe = onlyIntegers; // Compile-time error.
+}
+```
+
+The named `bind` field also makes `effect.bind(...)` discoverable without
+moving the consuming operation back onto a covariant nominal receiver. The
+implementation matches `Left` and `Right` directly instead of passing the
+consumed `Either` through another virtual method boundary. See
+[ADR 0001](adr/0001-scope-bound-contravariant-either-effect.md).
+
 ## Project design rule
 
 Before adding or changing a public instance member on `Either<L, R>`, audit
@@ -229,6 +270,8 @@ The branch review that introduced this document found and fixed three targets:
   combiner results are checked against the call site's static type arguments.
 - `flatten` remains an extension but now uses direct sealed-class pattern
   matching instead of delegating to `flatMap`.
+- `EitherEffect` is a contravariant record capability, so unsafe widening is
+  rejected before a binding block can execute.
 
 The other APIs added in this PR were audited as covariance-safe instance
 members or extensions: `onLeft`, `onRight`, `getOrNull`, `leftOrNull`,
@@ -293,6 +336,8 @@ Tests must cover:
 - Nested widening for operations such as `flatten`.
 - Callback invocation counts, including callbacks that must not run.
 - Successful execution without `TypeError`; do not hide the issue with casts.
+- Safe contravariant narrowing of `EitherEffect`, plus a compile-fail fixture
+  that requires unsafe widening to report `INVALID_ASSIGNMENT`.
 
 ## Review checklist
 

--- a/docs/either-variance-safety.md
+++ b/docs/either-variance-safety.md
@@ -182,33 +182,26 @@ covariantly widened receiver. It does not mean the operation itself is invalid.
 
 Binding consumes an `Either<L, R>`, so a nominal `EitherEffect<L>` class with
 an instance `bind` method is unsafe when Dart widens its covariant `L`. The
-binding capability instead uses a named record containing a generic function:
+binding capability instead aliases a library-private final scope whose type
+argument is a phantom function type:
 
 ```dart
-typedef EitherEffect<L> = ({
-  _EitherEffectBrand brand,
-  R Function<R>(Either<L, R> either) bind,
-});
+typedef EitherEffect<L> = _BindingScope<Never Function(L)>;
 ```
 
-The private-typed `brand` field does not mention `L`, so it does not affect the
-variance calculation. It prevents a consumer that has not received a
-package-issued marker from independently constructing the structural record.
-The binding callback remains the source of scope isolation and revocation;
-the brand itself is not a runtime authenticity check.
-
-The path to `L` has one sign flip:
+`_BindingScope<T>` is covariant in `T`, while a function is contravariant in
+its parameter. Composing those two positions makes the alias contravariant in
+`L`:
 
 ```text
-record field type:                 +
-bind function parameter:           -
-Either is covariant in L:          +
-                                    + x - x + = -
+alias target:                       +
+_BindingScope type argument:        +
+function parameter:                 -
+                                      + x + x - = -
 ```
 
-`EitherEffect` is therefore contravariant in `L`. An effect that accepts every
-`num` left value can safely be narrowed to one used only with `int`; the
-opposite assignment is rejected:
+An effect that accepts every `num` left value can therefore be narrowed to one
+used only with `int`; the opposite assignment is rejected:
 
 ```dart
 void demonstrate(
@@ -220,10 +213,18 @@ void demonstrate(
 }
 ```
 
-The named `bind` field also makes `effect.bind(...)` discoverable without
-moving the consuming operation back onto a covariant nominal receiver. The
-implementation matches `Left` and `Right` directly instead of passing the
-consumed `Either` through another virtual method boundary. See
+The phantom type has no runtime function value. `_BindingScope` itself owns the
+scope token and lifecycle state, and its named private constructor prevents the
+public typedef from forwarding an unnamed constructor. Keeping the carrier
+final and library-private also prevents external implementations. Copying an
+issued effect only aliases the same scope, so it cannot replace binding
+behavior or escape revocation.
+
+`BindEitherEffectExtension.bind` is declared in the same Dart library as the
+private scope. It ties the call-site `L` to `Either<L, R>` and delegates to a
+private generic operation that matches `Left` and `Right` directly. This keeps
+`effect.bind(...)` discoverable without introducing a consuming method on a
+covariant public class. See
 [ADR 0001](adr/0001-scope-bound-contravariant-either-effect.md).
 
 ## Project design rule
@@ -277,9 +278,9 @@ The branch review that introduced this document found and fixed three targets:
   combiner results are checked against the call site's static type arguments.
 - `flatten` remains an extension but now uses direct sealed-class pattern
   matching instead of delegating to `flatMap`.
-- `EitherEffect` is a branded, contravariant record capability, so unsafe
-  widening and independent construction are rejected before a binding block
-  can execute.
+- `EitherEffect` uses a private final scope with a contravariant phantom marker,
+  so unsafe widening, external construction, and replacement binding behavior
+  are rejected before a binding block can execute.
 
 The other APIs added in this PR were audited as covariance-safe instance
 members or extensions: `onLeft`, `onRight`, `getOrNull`, `leftOrNull`,
@@ -346,9 +347,8 @@ Tests must cover:
 - Successful execution without `TypeError`; do not hide the issue with casts.
 - Safe contravariant narrowing of `EitherEffect`, plus a compile-fail fixture
   that requires unsafe widening to report `INVALID_ASSIGNMENT`.
-- A consumer compile-fail fixture showing that a record with a compatible
-  generic `bind` function but no package-issued brand cannot be assigned to
-  `EitherEffect`.
+- A consumer compile-fail fixture showing that `EitherEffect<L>()` exposes no
+  unnamed constructor and reports `NEW_WITH_UNDEFINED_CONSTRUCTOR_DEFAULT`.
 
 ## Review checklist
 
@@ -358,6 +358,8 @@ Tests must cover:
 - Prefer a generic extension or top-level function for risky signatures.
 - Use direct `switch` pattern matching or a proven covariance-safe primitive.
 - Add widened `Never` and subtype regression tests.
+- Keep the `EitherEffect` carrier final and library-private, and keep its
+  constructor named and private so the public typedef cannot forward it.
 - Apply `@covarianceSafe` only after recording one of the accepted forms of
   evidence above; never treat the marker itself as evidence.
 - Verify with `dart analyze` and `dart test`.

--- a/docs/either-variance-safety.md
+++ b/docs/either-variance-safety.md
@@ -186,9 +186,16 @@ binding capability instead uses a named record containing a generic function:
 
 ```dart
 typedef EitherEffect<L> = ({
+  _EitherEffectBrand brand,
   R Function<R>(Either<L, R> either) bind,
 });
 ```
+
+The private-typed `brand` field does not mention `L`, so it does not affect the
+variance calculation. It prevents a consumer that has not received a
+package-issued marker from independently constructing the structural record.
+The binding callback remains the source of scope isolation and revocation;
+the brand itself is not a runtime authenticity check.
 
 The path to `L` has one sign flip:
 
@@ -270,8 +277,9 @@ The branch review that introduced this document found and fixed three targets:
   combiner results are checked against the call site's static type arguments.
 - `flatten` remains an extension but now uses direct sealed-class pattern
   matching instead of delegating to `flatMap`.
-- `EitherEffect` is a contravariant record capability, so unsafe widening is
-  rejected before a binding block can execute.
+- `EitherEffect` is a branded, contravariant record capability, so unsafe
+  widening and independent construction are rejected before a binding block
+  can execute.
 
 The other APIs added in this PR were audited as covariance-safe instance
 members or extensions: `onLeft`, `onRight`, `getOrNull`, `leftOrNull`,
@@ -338,6 +346,9 @@ Tests must cover:
 - Successful execution without `TypeError`; do not hide the issue with casts.
 - Safe contravariant narrowing of `EitherEffect`, plus a compile-fail fixture
   that requires unsafe widening to report `INVALID_ASSIGNMENT`.
+- A consumer compile-fail fixture showing that a record with a compatible
+  generic `bind` function but no package-issued brand cannot be assigned to
+  `EitherEffect`.
 
 ## Review checklist
 

--- a/example/lib/dart_either_styles.dart
+++ b/example/lib/dart_either_styles.dart
@@ -104,11 +104,11 @@ Future<Either<String, void>> eitherFlatMapCode() =>
 // ---------------------------------------------------------------------------
 
 Future<Either<String, void>> eitherBindingCode() =>
-    Either.futureBinding((e) async {
-      final nullableUser = await findUserByIdEither('user_id').bind(e);
-      final user = e.ensureNotNull(nullableUser, () => 'User is null');
-      final posts = await getPostsByUserEither(user).bind(e);
-      await doSomethingWithPostsEither(user, posts).bind(e);
+    Either.futureBinding((effect) async {
+      final nullableUser = await findUserByIdEither('user_id').bind(effect);
+      final user = effect.ensureNotNull(nullableUser, () => 'User is null');
+      final posts = await getPostsByUserEither(user).bind(effect);
+      await doSomethingWithPostsEither(user, posts).bind(effect);
     });
 
 // ---------------------------------------------------------------------------

--- a/example/lib/http_example/http_either_binding.dart
+++ b/example/lib/http_example/http_either_binding.dart
@@ -15,12 +15,12 @@ import 'shared_model.dart';
 
 /// Get response from Uri as either using Monad Comprehension
 Future<Either<AppError, dynamic>> httpGetAsEither(String uriString) =>
-    Either.futureBinding((e) async {
+    Either.futureBinding((effect) async {
       // Create Uri
       final uri = Either.catchError(
         toAppError('Parse $uriString'),
         () => Uri.parse(uriString),
-      ).bind(e);
+      ).bind(effect);
 
       // Get response
       final response = await Either.catchFutureError(
@@ -29,13 +29,13 @@ Future<Either<AppError, dynamic>> httpGetAsEither(String uriString) =>
           await delay(500);
           return http.get(uri);
         },
-      ).bind(e);
+      ).bind(effect);
 
       final statusCode = response.statusCode;
       final body = response.body;
 
       // Check status code
-      e.ensure(
+      effect.ensure(
         statusCode >= 200 && statusCode < 300,
         () => AppError(
           HttpException(
@@ -51,7 +51,7 @@ Future<Either<AppError, dynamic>> httpGetAsEither(String uriString) =>
       return Either.catchError(
         toAppError('jsonDecode: $body'),
         () => jsonDecode(body),
-      ).bind(e);
+      ).bind(effect);
     });
 
 // ---------------------------------------------------------------------------
@@ -64,16 +64,16 @@ void main() async {
   ) =>
       Either.parTraverseN(
         values: users,
-        mapper: (User user) => () => Either.futureBinding((e) async {
+        mapper: (User user) => () => Either.futureBinding((effect) async {
               print('--> Get posts for $user...');
 
               // Get posts for user
               final list = await httpGetAsEither(
                       'https://jsonplaceholder.typicode.com/posts?userId=${user.id}')
-                  .bind(e);
+                  .bind(effect);
 
               // Convert to post models
-              final posts = toPosts(list).bind(e);
+              final posts = toPosts(list).bind(effect);
 
               // Return user and posts
               return (user: user, posts: posts);
@@ -82,17 +82,17 @@ void main() async {
       );
 
   final result = await Either.futureBinding<AppError, BuiltList<UserAndPosts>>(
-    (e) async {
+    (effect) async {
       // Get user list
       final list =
           await httpGetAsEither('https://jsonplaceholder.typicode.com/users')
-              .bind(e);
+              .bind(effect);
 
       // Convert to user models
-      final users = toUsers(list).bind(e);
+      final users = toUsers(list).bind(effect);
 
       // Get posts for each user
-      return await getPosts(users).bind(e);
+      return await getPosts(users).bind(effect);
     },
   );
 

--- a/lib/src/binding.dart
+++ b/lib/src/binding.dart
@@ -3,6 +3,10 @@ import 'package:meta/meta.dart';
 import 'dart_either.dart';
 import 'extensions.dart';
 
+// -----------------------------------------------------------------------------
+// Extensions on EitherEffect
+// -----------------------------------------------------------------------------
+
 /// Provides [ensure] on a scope-bound [EitherEffect].
 extension EnsureEitherEffectExtension<L> on EitherEffect<L> {
   /// Continues the binding scope when [value] is `true`.
@@ -79,6 +83,10 @@ extension BindFutureEitherEffectExtension<L> on EitherEffect<L> {
   Future<R> bindFuture<R>(Future<Either<L, R>> eitherFuture) =>
       eitherFuture.then(bind);
 }
+
+// -----------------------------------------------------------------------------
+// Binding syntax extensions: receive an EitherEffect
+// -----------------------------------------------------------------------------
 
 /// Provides binding syntax on an [Either].
 extension BindEitherExtension<L, R> on Either<L, R> {

--- a/lib/src/binding.dart
+++ b/lib/src/binding.dart
@@ -3,6 +3,10 @@ import 'package:meta/meta.dart';
 import 'dart_either.dart';
 import 'extensions.dart';
 
+// -----------------------------------------------------------------------------
+// Extensions on EitherEffect
+// -----------------------------------------------------------------------------
+
 /// Provides [ensure] on a scope-bound [EitherEffect].
 extension EnsureEitherEffectExtension<L> on EitherEffect<L> {
   /// Continues the binding scope when [value] is `true`.
@@ -80,6 +84,10 @@ extension BindFutureEitherEffectExtension<L> on EitherEffect<L> {
       eitherFuture.then(bind);
 }
 
+// -----------------------------------------------------------------------------
+// Binding syntax extensions: receive an EitherEffect
+// -----------------------------------------------------------------------------
+
 /// Provides binding syntax on an [Either].
 extension BindEitherExtension<L, R> on Either<L, R> {
   /// Returns this [Either]'s right value through [effect].
@@ -116,4 +124,28 @@ extension BindEitherFutureExtension<L, R> on Future<Either<L, R>> {
   /// ```
   @monadComprehensions
   Future<R> bind(EitherEffect<L> effect) => then(effect.bind);
+}
+/// Provides binding syntax on a nullable value.
+extension BindNullableValueExtension<R extends Object> on R? {
+  /// Returns this value as non-nullable [R] through [effect].
+  ///
+  /// When this value is `null`, evaluates [orLeft] and short-circuits the
+  /// [Either.binding] or [Either.futureBinding] scope that owns [effect]
+  /// with the result in a [Left].
+  ///
+  /// See [Either.binding] and [Either.futureBinding].
+  ///
+  /// ### Example
+  /// ```dart
+  /// final result = Either<String, int>.binding((effect) {
+  ///   final int? nullableValue = 1;
+  ///   final int value = nullableValue.bind(effect, () => 'missing');
+  ///   return value + 1;
+  /// }); // Right(2)
+  /// ```
+  @monadComprehensions
+  R bind<L>(EitherEffect<L> effect, L Function() orLeft) {
+    final value = this;
+    return value ?? effect.bind<R>(orLeft().left<R>());
+  }
 }

--- a/lib/src/binding.dart
+++ b/lib/src/binding.dart
@@ -1,19 +1,7 @@
-import 'dart:math';
-
 import 'package:meta/meta.dart';
 
 import 'dart_either.dart';
 import 'extensions.dart';
-
-/// TODO
-extension BindEitherEffectExtension<L> on EitherEffect<L> {
-  /// Attempt to get right value of [either].
-  /// Or throws a [ControlError].
-  ///
-  /// See [Either.binding] and [Either.futureBinding].
-  @monadComprehensions
-  R bind<R>(Either<L, R> either) => this<R>(either);
-}
 
 /// Provide [ensure] extension on [EitherEffect].
 extension EnsureEitherEffectExtension<L> on EitherEffect<L> {
@@ -37,7 +25,7 @@ extension EnsureEitherEffectExtension<L> on EitherEffect<L> {
   /// ```
   @monadComprehensions
   void ensure(bool value, L Function() orLeft) =>
-      value ? null : this<void>(orLeft().left<void>());
+      value ? null : bind<Never>(orLeft().left<Never>());
 }
 
 /// Provide [ensureNotNull] extension on [EitherEffect].
@@ -67,7 +55,7 @@ extension EnsureNotNullEitherEffectExtension<L> on EitherEffect<L> {
   @useResult
   @monadComprehensions
   R ensureNotNull<R extends Object>(R? value, L Function() orLeft) =>
-      value ?? this<R>(orLeft().left<R>());
+      value ?? bind<R>(orLeft().left<R>());
 }
 
 /// Provide [bindFuture] extension on [EitherEffect].
@@ -79,7 +67,7 @@ extension BindFutureEitherEffectExtension<L> on EitherEffect<L> {
   /// See [Either.futureBinding].
   @monadComprehensions
   Future<R> bindFuture<R>(Future<Either<L, R>> eitherFuture) =>
-      eitherFuture.then((e) => this<R>(e));
+      eitherFuture.then(bind);
 }
 
 /// Provide [bind] extension on an [Either].
@@ -89,7 +77,7 @@ extension BindEitherExtension<L, R> on Either<L, R> {
   ///
   /// See [Either.binding] and [Either.futureBinding].
   @monadComprehensions
-  R bind(EitherEffect<L> effect) => effect<R>(this);
+  R bind(EitherEffect<L> effect) => effect.bind<R>(this);
 }
 
 /// Provide [bind] extension on a [Future] of [Either].
@@ -99,5 +87,5 @@ extension BindEitherFutureExtension<L, R> on Future<Either<L, R>> {
   ///
   /// See [Either.futureBinding].
   @monadComprehensions
-  Future<R> bind(EitherEffect<L> effect) => then((e) => effect<R>(e));
+  Future<R> bind(EitherEffect<L> effect) => then(effect.bind);
 }

--- a/lib/src/binding.dart
+++ b/lib/src/binding.dart
@@ -3,54 +3,52 @@ import 'package:meta/meta.dart';
 import 'dart_either.dart';
 import 'extensions.dart';
 
-/// Provide [ensure] extension on [EitherEffect].
+/// Provides [ensure] on a scope-bound [EitherEffect].
 extension EnsureEitherEffectExtension<L> on EitherEffect<L> {
-  /// Ensure check if the [value] is `true`,
-  /// and if it is it allows the `Either.binding(...)` to continue.
-  /// In case it is `false`, then it short-circuits the binding and returns
-  /// the provided value by [orLeft] inside a [Left].
+  /// Continues the binding scope when [value] is `true`.
+  ///
+  /// When [value] is `false`, evaluates [orLeft] and short-circuits the scope
+  /// with its result in a [Left].
   ///
   /// See [Either.binding] and [Either.futureBinding].
   ///
   /// ### Example
   /// ```dart
-  /// final res = Either<String, int>.binding((e) {
-  ///   e.ensure(true, () => '');
+  /// final result = Either<String, int>.binding((effect) {
+  ///   effect.ensure(true, () => 'unused');
   ///   print('ensure(true) passes');
-  ///   e.ensure(false, () => 'failed');
+  ///   effect.ensure(false, () => 'failed');
   ///   return 1;
   /// });
   /// // print: 'ensure(true) passes'
-  /// // res: Left('failed')
+  /// // result: Left('failed')
   /// ```
   @monadComprehensions
   void ensure(bool value, L Function() orLeft) =>
       value ? null : bind<Never>(orLeft().left<Never>());
 }
 
-/// Provide [ensureNotNull] extension on [EitherEffect].
+/// Provides [ensureNotNull] on a scope-bound [EitherEffect].
 extension EnsureNotNullEitherEffectExtension<L> on EitherEffect<L> {
-  /// Ensures that [value] is not null.
-  /// When the value is not null, then it will be returned as non null and the check value is now smart-checked to non-null.
-  /// Otherwise, if the [value] is null then the `Either.binding(...)` will short-circuit with [orLeft] inside of [Left].
+  /// Returns [value] as a non-nullable [R] when it is not `null`.
+  ///
+  /// When [value] is `null`, evaluates [orLeft] and short-circuits the binding
+  /// scope with its result in a [Left]. Assign the returned value; Dart does
+  /// not promote the original variable across this method call.
   ///
   /// See [Either.binding] and [Either.futureBinding].
   ///
   /// ### Example
   /// ```dart
-  /// final res = Either<String, int>.binding((e) {
-  ///   int? x = 1;
-  ///   e.ensureNotNull(x, () => 'passes');
-  ///   print(x);
-  ///
-  ///   x = null;
-  ///   e.ensureNotNull(x, () => 'failed');
-  ///   print(x);
-  ///
-  ///   return 1;
+  /// final result = Either<String, int>.binding((effect) {
+  ///   int? nullableValue = 1;
+  ///   final value = effect.ensureNotNull(
+  ///     nullableValue,
+  ///     () => 'missing',
+  ///   );
+  ///   return value + 1;
   /// });
-  /// // println: '1'
-  /// // res: Left('failed')
+  /// // result: Right(2)
   /// ```
   @useResult
   @monadComprehensions
@@ -58,34 +56,63 @@ extension EnsureNotNullEitherEffectExtension<L> on EitherEffect<L> {
       value ?? bind<R>(orLeft().left<R>());
 }
 
-/// Provide [bindFuture] extension on [EitherEffect].
+/// Provides [bindFuture] on a scope-bound [EitherEffect].
 extension BindFutureEitherEffectExtension<L> on EitherEffect<L> {
-  /// Attempt to get right value of [eitherFuture].
-  /// Or return a [Future] that completes with a [ControlError].
+  /// Returns the right value produced by [eitherFuture].
+  ///
+  /// A produced [Left] short-circuits the surrounding [Either.futureBinding]
+  /// scope. An error emitted by [eitherFuture] propagates unchanged.
   /// This is a shorthand for `eitherFuture.then(bind)`.
   ///
   /// See [Either.futureBinding].
+  ///
+  /// ### Example
+  /// ```dart
+  /// final result = await Either.futureBinding<String, int>((effect) async {
+  ///   return effect.bindFuture(
+  ///     Future.value(Either<String, int>.right(1)),
+  ///   );
+  /// }); // Right(1)
+  /// ```
   @monadComprehensions
   Future<R> bindFuture<R>(Future<Either<L, R>> eitherFuture) =>
       eitherFuture.then(bind);
 }
 
-/// Provide [bind] extension on an [Either].
+/// Provides binding syntax on an [Either].
 extension BindEitherExtension<L, R> on Either<L, R> {
-  /// Attempt to get right value of [this].
-  /// Or throws a [ControlError].
+  /// Returns this [Either]'s right value through [effect].
+  ///
+  /// A [Left] short-circuits the [Either.binding] or [Either.futureBinding]
+  /// scope that owns [effect].
   ///
   /// See [Either.binding] and [Either.futureBinding].
+  ///
+  /// ### Example
+  /// ```dart
+  /// final result = Either<String, int>.binding((effect) {
+  ///   return Either<String, int>.right(1).bind(effect);
+  /// }); // Right(1)
+  /// ```
   @monadComprehensions
   R bind(EitherEffect<L> effect) => effect.bind<R>(this);
 }
 
-/// Provide [bind] extension on a [Future] of [Either].
+/// Provides binding syntax on a [Future] of [Either].
 extension BindEitherFutureExtension<L, R> on Future<Either<L, R>> {
-  /// Attempt to get right value of [this].
-  /// Or return a [Future] that completes with a [ControlError].
+  /// Returns the right value produced by this future through [effect].
+  ///
+  /// A produced [Left] short-circuits the [Either.futureBinding] scope that
+  /// owns [effect]. An error emitted by this future propagates unchanged.
   ///
   /// See [Either.futureBinding].
+  ///
+  /// ### Example
+  /// ```dart
+  /// final result = await Either.futureBinding<String, int>((effect) async {
+  ///   return Future.value(Either<String, int>.right(1)).bind(effect);
+  /// }); // Right(1)
+  /// ```
   @monadComprehensions
   Future<R> bind(EitherEffect<L> effect) => then(effect.bind);
 }

--- a/lib/src/binding.dart
+++ b/lib/src/binding.dart
@@ -1,7 +1,19 @@
+import 'dart:math';
+
 import 'package:meta/meta.dart';
 
 import 'dart_either.dart';
 import 'extensions.dart';
+
+/// TODO
+extension BindEitherEffectExtension<L> on EitherEffect<L> {
+  /// Attempt to get right value of [either].
+  /// Or throws a [ControlError].
+  ///
+  /// See [Either.binding] and [Either.futureBinding].
+  @monadComprehensions
+  R bind<R>(Either<L, R> either) => this<R>(either);
+}
 
 /// Provide [ensure] extension on [EitherEffect].
 extension EnsureEitherEffectExtension<L> on EitherEffect<L> {
@@ -25,7 +37,7 @@ extension EnsureEitherEffectExtension<L> on EitherEffect<L> {
   /// ```
   @monadComprehensions
   void ensure(bool value, L Function() orLeft) =>
-      value ? null : bind(orLeft().left());
+      value ? null : this<void>(orLeft().left<void>());
 }
 
 /// Provide [ensureNotNull] extension on [EitherEffect].
@@ -55,7 +67,7 @@ extension EnsureNotNullEitherEffectExtension<L> on EitherEffect<L> {
   @useResult
   @monadComprehensions
   R ensureNotNull<R extends Object>(R? value, L Function() orLeft) =>
-      value ?? bind(orLeft().left());
+      value ?? this<R>(orLeft().left<R>());
 }
 
 /// Provide [bindFuture] extension on [EitherEffect].
@@ -67,7 +79,7 @@ extension BindFutureEitherEffectExtension<L> on EitherEffect<L> {
   /// See [Either.futureBinding].
   @monadComprehensions
   Future<R> bindFuture<R>(Future<Either<L, R>> eitherFuture) =>
-      eitherFuture.then(bind);
+      eitherFuture.then((e) => this<R>(e));
 }
 
 /// Provide [bind] extension on an [Either].
@@ -77,7 +89,7 @@ extension BindEitherExtension<L, R> on Either<L, R> {
   ///
   /// See [Either.binding] and [Either.futureBinding].
   @monadComprehensions
-  R bind(EitherEffect<L> effect) => effect.bind(this);
+  R bind(EitherEffect<L> effect) => effect<R>(this);
 }
 
 /// Provide [bind] extension on a [Future] of [Either].
@@ -87,5 +99,5 @@ extension BindEitherFutureExtension<L, R> on Future<Either<L, R>> {
   ///
   /// See [Either.futureBinding].
   @monadComprehensions
-  Future<R> bind(EitherEffect<L> effect) => effect.bindFuture(this);
+  Future<R> bind(EitherEffect<L> effect) => then((e) => effect<R>(e));
 }

--- a/lib/src/binding.dart
+++ b/lib/src/binding.dart
@@ -41,11 +41,8 @@ extension EnsureNotNullEitherEffectExtension<L> on EitherEffect<L> {
   /// ### Example
   /// ```dart
   /// final result = Either<String, int>.binding((effect) {
-  ///   int? nullableValue = 1;
-  ///   final value = effect.ensureNotNull(
-  ///     nullableValue,
-  ///     () => 'missing',
-  ///   );
+  ///   final int? nullableValue = 1;
+  ///   final value = effect.ensureNotNull(nullableValue, () => 'missing');
   ///   return value + 1;
   /// });
   /// // result: Right(2)
@@ -69,10 +66,14 @@ extension BindFutureEitherEffectExtension<L> on EitherEffect<L> {
   /// ### Example
   /// ```dart
   /// final result = await Either.futureBinding<String, int>((effect) async {
-  ///   return effect.bindFuture(
+  ///   final int userId = await effect.bindFuture(
   ///     Future.value(Either<String, int>.right(1)),
   ///   );
-  /// }); // Right(1)
+  ///   final int postCount = await effect.bindFuture(
+  ///     Future.value(Either<String, int>.right(userId + 2)),
+  ///   );
+  ///   return postCount;
+  /// }); // Right(3)
   /// ```
   @monadComprehensions
   Future<R> bindFuture<R>(Future<Either<L, R>> eitherFuture) =>

--- a/lib/src/binding.dart
+++ b/lib/src/binding.dart
@@ -3,10 +3,6 @@ import 'package:meta/meta.dart';
 import 'dart_either.dart';
 import 'extensions.dart';
 
-// -----------------------------------------------------------------------------
-// Extensions on EitherEffect
-// -----------------------------------------------------------------------------
-
 /// Provides [ensure] on a scope-bound [EitherEffect].
 extension EnsureEitherEffectExtension<L> on EitherEffect<L> {
   /// Continues the binding scope when [value] is `true`.
@@ -84,10 +80,6 @@ extension BindFutureEitherEffectExtension<L> on EitherEffect<L> {
       eitherFuture.then(bind);
 }
 
-// -----------------------------------------------------------------------------
-// Binding syntax extensions: receive an EitherEffect
-// -----------------------------------------------------------------------------
-
 /// Provides binding syntax on an [Either].
 extension BindEitherExtension<L, R> on Either<L, R> {
   /// Returns this [Either]'s right value through [effect].
@@ -124,28 +116,4 @@ extension BindEitherFutureExtension<L, R> on Future<Either<L, R>> {
   /// ```
   @monadComprehensions
   Future<R> bind(EitherEffect<L> effect) => then(effect.bind);
-}
-/// Provides binding syntax on a nullable value.
-extension BindNullableValueExtension<R extends Object> on R? {
-  /// Returns this value as non-nullable [R] through [effect].
-  ///
-  /// When this value is `null`, evaluates [orLeft] and short-circuits the
-  /// [Either.binding] or [Either.futureBinding] scope that owns [effect]
-  /// with the result in a [Left].
-  ///
-  /// See [Either.binding] and [Either.futureBinding].
-  ///
-  /// ### Example
-  /// ```dart
-  /// final result = Either<String, int>.binding((effect) {
-  ///   final int? nullableValue = 1;
-  ///   final int value = nullableValue.bind(effect, () => 'missing');
-  ///   return value + 1;
-  /// }); // Right(2)
-  /// ```
-  @monadComprehensions
-  R bind<L>(EitherEffect<L> effect, L Function() orLeft) {
-    final value = this;
-    return value ?? effect.bind<R>(orLeft().left<R>());
-  }
 }

--- a/lib/src/dart_either.dart
+++ b/lib/src/dart_either.dart
@@ -1061,6 +1061,12 @@ final class _MonadComprehensions {
 /// [Either.futureBinding]. Invoking it after its scope has completed throws a
 /// [StateError].
 ///
+/// The `brand` field is a construction marker backed by a library-private
+/// type. Treat it as an implementation detail: do not read or copy it, and do
+/// not construct `EitherEffect` records manually. Scope and revocation
+/// guarantees apply to the capability supplied directly by the binding
+/// callback.
+///
 /// `EitherEffect` is contravariant in [L]: an effect accepting `num` errors can
 /// be used where one accepting only `int` errors is required, while the unsafe
 /// opposite assignment is rejected at compile time.
@@ -1068,7 +1074,7 @@ final class _MonadComprehensions {
 /// ### Example
 /// ```dart
 /// final result = Either<String, int>.binding((effect) {
-///   final value = effect.bind(Either<String, int>.right(1));
+///   final int value = effect.bind(Either<String, int>.right(1));
 ///   return value + 1;
 /// }); // Right(2)
 /// ```

--- a/lib/src/dart_either.dart
+++ b/lib/src/dart_either.dart
@@ -183,22 +183,21 @@ sealed class Either<L, R> {
   /// ```
   factory Either.binding(
       @monadComprehensions R Function(EitherEffect<L> effect) block) {
-    final scope = _BindingScope<L>(_Token());
-    final eitherEffect = scope.openEitherEffect();
+    final EitherEffect<L> effect = _BindingScope<Never Function(L)>._(_Token());
 
     try {
-      final value = block(eitherEffect);
-      scope.throwIfRaised();
+      final value = block(effect);
+      effect._throwIfRaised();
 
       return Either.right(value);
     } on ControlError<L> catch (e) {
-      if (identical(scope._token, e._token)) {
+      if (identical(effect._token, e._token)) {
         return Either.left(e._value);
       } else {
         rethrow;
       }
     } finally {
-      scope.close();
+      effect._close();
     }
   }
 
@@ -309,20 +308,19 @@ sealed class Either<L, R> {
   /// ```
   static Future<Either<L, R>> futureBinding<L, R>(
       @monadComprehensions FutureOr<R> Function(EitherEffect<L> effect) block) {
-    final scope = _BindingScope<L>(_Token());
-    final eitherEffect = scope.openEitherEffect();
+    final EitherEffect<L> effect = _BindingScope<Never Function(L)>._(_Token());
 
-    return Future.sync(() => block(eitherEffect))
+    return Future.sync(() => block(effect))
         .then((value) {
-          scope.throwIfRaised();
+          effect._throwIfRaised();
 
           return Either<L, R>.right(value);
         })
         .onError<ControlError<L>>(
           (e, s) => Either.left(e._value),
-          test: (e) => identical(scope._token, e._token),
+          test: (e) => identical(effect._token, e._token),
         )
-        .whenComplete(() => scope.close());
+        .whenComplete(() => effect._close());
   }
 
   /// Evaluates the specified [block] and wrap the result in a [Right].
@@ -1079,14 +1077,7 @@ final class _MonadComprehensions {
 /// }); // Right(2)
 /// ```
 @monadComprehensions
-typedef EitherEffect<L> = ({
-  _EitherEffectBrand brand,
-  R Function<R>(Either<L, R> either) bind,
-});
-
-final class _EitherEffectBrand {
-  const _EitherEffectBrand._();
-}
+typedef EitherEffect<L> = _BindingScope<Never Function(L)>;
 
 /// Internal control-flow signal raised when [EitherEffect] binds a [Left].
 ///
@@ -1120,38 +1111,47 @@ enum _BindingPhase {
   closed,
 }
 
-final class _BindingScope<L> {
+/// AcceptsLeft is marker type, covariant.
+/// `Never Function(L)` contravariant L.
+/// -> EitherEffect<L> contravariant L.
+/// final class + private ctor + library-private -> caller cannot instantiate or extend this class.
+final class _BindingScope<AcceptsLeft extends Function> {
   final _Token _token;
   var _phase = _BindingPhase.active;
 
-  _BindingScope(this._token);
+  // NOTE: do not make _BindingScope's constructor public.
 
-  void close() {
+  _BindingScope._(this._token);
+
+  void _close() {
     _phase = _BindingPhase.closed;
   }
 
-  void throwIfRaised() {
+  void _throwIfRaised() {
     if (_phase == _BindingPhase.raised) {
       throw StateError('Binding short-circuit was intercepted.');
     }
   }
 
-  EitherEffect<L> openEitherEffect() {
-    return (
-      brand: const _EitherEffectBrand._(),
-      bind: <R>(Either<L, R> either) {
-        if (_phase != _BindingPhase.active) {
-          throw StateError('EitherEffect was used outside its binding scope.');
-        }
+  @monadComprehensions
+  R _bind<L, R>(Either<L, R> either) {
+    if (_phase != _BindingPhase.active) {
+      throw StateError('EitherEffect was used outside its binding scope.');
+    }
 
-        switch (either) {
-          case Left(value: final value):
-            _phase = _BindingPhase.raised;
-            throw ControlError<L>._(value, _token);
-          case Right(value: final value):
-            return value;
-        }
-      }
-    );
+    switch (either) {
+      case Left(value: final value):
+        _phase = _BindingPhase.raised;
+        throw ControlError<L>._(value, _token);
+      case Right(value: final value):
+        return value;
+    }
   }
+}
+
+/// TODO
+extension BindEitherEffectExtension<L> on EitherEffect<L> {
+  /// TODO
+  @monadComprehensions
+  R bind<R>(Either<L, R> either) => _bind<L, R>(either);
 }

--- a/lib/src/dart_either.dart
+++ b/lib/src/dart_either.dart
@@ -1049,8 +1049,8 @@ final class _MonadComprehensions {
 
 /// A scope-bound capability for binding [Either] values with the same [L].
 ///
-/// The generic `bind` function returns an [Either]'s [Right.value]. Binding a
-/// [Left] short-circuits the surrounding [Either.binding] or
+/// [BindEitherEffectExtension.bind] returns an [Either]'s [Right.value].
+/// Binding a [Left] short-circuits the surrounding [Either.binding] or
 /// [Either.futureBinding] scope with that left value.
 ///
 /// Obtain a library-managed capability from the binding callback. A capability
@@ -1059,11 +1059,10 @@ final class _MonadComprehensions {
 /// [Either.futureBinding]. Invoking it after its scope has completed throws a
 /// [StateError].
 ///
-/// The `brand` field is a construction marker backed by a library-private
-/// type. Treat it as an implementation detail: do not read or copy it, and do
-/// not construct `EitherEffect` records manually. Scope and revocation
-/// guarantees apply to the capability supplied directly by the binding
-/// callback.
+/// Construction and binding behavior are owned by this library. Code outside
+/// the library cannot instantiate, extend, implement, or replace the binding
+/// behavior of an `EitherEffect`. Assigning the capability to another variable
+/// aliases the same binding scope; it does not create an independent effect.
 ///
 /// `EitherEffect` is contravariant in [L]: an effect accepting `num` errors can
 /// be used where one accepting only `int` errors is required, while the unsafe
@@ -1111,15 +1110,18 @@ enum _BindingPhase {
   closed,
 }
 
-/// AcceptsLeft is marker type, covariant.
-/// `Never Function(L)` contravariant L.
-/// -> EitherEffect<L> contravariant L.
-/// final class + private ctor + library-private -> caller cannot instantiate or extend this class.
+/// Private binding scope with a covariant phantom [AcceptsLeft] marker.
+///
+/// `EitherEffect<L>` supplies `Never Function(L)` as the marker. Because a
+/// function is contravariant in its parameter, composing that marker with this
+/// class's covariant type parameter makes `EitherEffect` contravariant in `L`.
+///
+/// This class must remain final and library-private. Its constructor must
+/// remain named and private because a public typedef forwards an unnamed
+/// constructor from its aliased class.
 final class _BindingScope<AcceptsLeft extends Function> {
   final _Token _token;
   var _phase = _BindingPhase.active;
-
-  // NOTE: do not make _BindingScope's constructor public.
 
   _BindingScope._(this._token);
 
@@ -1149,9 +1151,22 @@ final class _BindingScope<AcceptsLeft extends Function> {
   }
 }
 
-/// TODO
+/// Provides binding syntax on a scope-bound [EitherEffect].
 extension BindEitherEffectExtension<L> on EitherEffect<L> {
-  /// TODO
+  /// Returns [either]'s [Right.value].
+  ///
+  /// A [Left] short-circuits the [Either.binding] or [Either.futureBinding]
+  /// scope that owns this effect.
+  ///
+  /// See [Either.binding] and [Either.futureBinding].
+  ///
+  /// ### Example
+  /// ```dart
+  /// final result = Either<String, int>.binding((effect) {
+  ///   final int value = effect.bind(Either<String, int>.right(1));
+  ///   return value + 1;
+  /// }); // Right(2)
+  /// ```
   @monadComprehensions
   R bind<R>(Either<L, R> either) => _bind<L, R>(either);
 }

--- a/lib/src/dart_either.dart
+++ b/lib/src/dart_either.dart
@@ -1043,7 +1043,9 @@ final class _MonadComprehensions {
 
 /// TODO
 @monadComprehensions
-typedef EitherEffect<L> = R Function<R>(Either<L, R> either);
+typedef EitherEffect<L> = ({
+  R Function<R>(Either<L, R> either) bind,
+});
 
 /// Error thrown by [EitherEffect].
 /// Must not be caught.
@@ -1089,15 +1091,17 @@ final class _BindingScope<L> {
   }
 
   EitherEffect<L> openEitherEffect() {
-    return <R>(Either<L, R> either) {
-      if (_phase != _BindingPhase.active) {
-        throw StateError('EitherEffect was used outside its binding scope.');
-      }
+    return (
+      bind: <R>(Either<L, R> either) {
+        if (_phase != _BindingPhase.active) {
+          throw StateError('EitherEffect was used outside its binding scope.');
+        }
 
-      return either.getOrHandle((v) {
-        _phase = _BindingPhase.raised;
-        throw ControlError<L>._(v, _token);
-      });
-    };
+        return either.getOrHandle((v) {
+          _phase = _BindingPhase.raised;
+          throw ControlError<L>._(v, _token);
+        });
+      }
+    );
   }
 }

--- a/lib/src/dart_either.dart
+++ b/lib/src/dart_either.dart
@@ -5,15 +5,16 @@ import 'package:meta/meta.dart';
 import 'package:meta/meta_meta.dart';
 
 import 'binding.dart';
+import 'either_extensions.dart';
 import 'extensions.dart';
 import 'internal.dart';
 import 'utils/semaphore.dart';
-import 'either_extensions.dart';
 
 /// Map [error] and [stackTrace] to a [T] value.
 typedef ErrorMapper<T> = T Function(Object error, StackTrace stackTrace);
 
 extension on Object {
+  @pragma('vm:always-consider-inlining')
   @pragma('vm:prefer-inline')
   @pragma('dart2js:tryInline')
   Object throwIfFatal() {
@@ -175,16 +176,22 @@ sealed class Either<L, R> {
   /// ```
   factory Either.binding(
       @monadComprehensions R Function(EitherEffect<L> effect) block) {
-    final eitherEffect = _EitherEffectImpl<L>(_Token());
+    final scope = _BindingScope<L>(_Token());
+    final eitherEffect = scope.openEitherEffect();
 
     try {
-      return Either.right(block(eitherEffect));
+      final value = block(eitherEffect);
+      scope.throwIfRaised();
+
+      return Either.right(value);
     } on ControlError<L> catch (e) {
-      if (identical(eitherEffect._token, e._token)) {
+      if (identical(scope._token, e._token)) {
         return Either.left(e._value);
       } else {
         rethrow;
       }
+    } finally {
+      scope.close();
     }
   }
 
@@ -294,14 +301,20 @@ sealed class Either<L, R> {
   /// ```
   static Future<Either<L, R>> futureBinding<L, R>(
       @monadComprehensions FutureOr<R> Function(EitherEffect<L> effect) block) {
-    final eitherEffect = _EitherEffectImpl<L>(_Token());
+    final scope = _BindingScope<L>(_Token());
+    final eitherEffect = scope.openEitherEffect();
 
     return Future.sync(() => block(eitherEffect))
-        .then((value) => Either<L, R>.right(value))
+        .then((value) {
+          scope.throwIfRaised();
+
+          return Either<L, R>.right(value);
+        })
         .onError<ControlError<L>>(
           (e, s) => Either.left(e._value),
-          test: (e) => identical(eitherEffect._token, e._token),
-        );
+          test: (e) => identical(scope._token, e._token),
+        )
+        .whenComplete(() => scope.close());
   }
 
   /// Evaluates the specified [block] and wrap the result in a [Right].
@@ -1023,22 +1036,14 @@ class Right<L, R> extends Either<L, R> {
 @internal
 const monadComprehensions = _MonadComprehensions();
 
-@Target({TargetKind.method, TargetKind.parameter})
+@Target({TargetKind.method, TargetKind.parameter, TargetKind.typedefType})
 final class _MonadComprehensions {
   const _MonadComprehensions();
 }
 
-/// Used for monad comprehensions.
-/// Cannot implement or extend this class.
-@sealed
-sealed class EitherEffect<L> {
-  EitherEffect._();
-
-  /// Attempt to get right value of [either].
-  /// Or throws a [ControlError].
-  @monadComprehensions
-  R bind<R>(Either<L, R> either);
-}
+/// TODO
+@monadComprehensions
+typedef EitherEffect<L> = R Function<R>(Either<L, R> either);
 
 /// Error thrown by [EitherEffect].
 /// Must not be caught.
@@ -1061,12 +1066,38 @@ class _Token {
   String toString() => 'Token(${hashCode.toRadixString(16)})';
 }
 
-class _EitherEffectImpl<L> extends EitherEffect<L> {
+enum _BindingPhase {
+  active,
+  raised,
+  closed,
+}
+
+final class _BindingScope<L> {
   final _Token _token;
+  var _phase = _BindingPhase.active;
 
-  _EitherEffectImpl(this._token) : super._();
+  _BindingScope(this._token);
 
-  @override
-  R bind<R>(Either<L, R> either) =>
-      either.getOrHandle((v) => throw ControlError._(v, _token));
+  void close() {
+    _phase = _BindingPhase.closed;
+  }
+
+  void throwIfRaised() {
+    if (_phase == _BindingPhase.raised) {
+      throw StateError('Binding short-circuit was intercepted.');
+    }
+  }
+
+  EitherEffect<L> openEitherEffect() {
+    return <R>(Either<L, R> either) {
+      if (_phase != _BindingPhase.active) {
+        throw StateError('EitherEffect was used outside its binding scope.');
+      }
+
+      return either.getOrHandle((v) {
+        _phase = _BindingPhase.raised;
+        throw ControlError<L>._(v, _token);
+      });
+    };
+  }
 }

--- a/lib/src/dart_either.dart
+++ b/lib/src/dart_either.dart
@@ -1074,8 +1074,13 @@ final class _MonadComprehensions {
 /// ```
 @monadComprehensions
 typedef EitherEffect<L> = ({
+  _EitherEffectBrand brand,
   R Function<R>(Either<L, R> either) bind,
 });
+
+final class _EitherEffectBrand {
+  const _EitherEffectBrand._();
+}
 
 /// Internal control-flow signal raised when [EitherEffect] binds a [Left].
 ///
@@ -1127,6 +1132,7 @@ final class _BindingScope<L> {
 
   EitherEffect<L> openEitherEffect() {
     return (
+      brand: const _EitherEffectBrand._(),
       bind: <R>(Either<L, R> either) {
         if (_phase != _BindingPhase.active) {
           throw StateError('EitherEffect was used outside its binding scope.');

--- a/lib/src/dart_either.dart
+++ b/lib/src/dart_either.dart
@@ -145,11 +145,10 @@ sealed class Either<L, R> {
   /// Either<ExampleError, int> provideY() { ... }
   /// Either<ExampleError, int> provideZ(int x, int y) { ... }
   ///
-  /// Either<ExampleError, int> result =
-  ///     Either<ExampleError, int>.binding((effect) {
-  ///   int x = provideX().bind(effect);
-  ///   int y = effect.bind(provideY());
-  ///   int z = provideZ(x, y).bind(effect);
+  /// final result = Either<ExampleError, int>.binding((effect) {
+  ///   final int x = provideX().bind(effect);
+  ///   final int y = effect.bind(provideY());
+  ///   final int z = provideZ(x, y).bind(effect);
   ///   return z;
   /// });
   /// ```
@@ -166,20 +165,20 @@ sealed class Either<L, R> {
   /// int canThrowAnError() { ... }
   ///
   /// // DON'T
-  /// Either<ExampleError, int> result =
-  ///     Either<ExampleError, int>.binding((effect) {
-  ///   int value = canThrowAnError();
+  /// final badResult = Either<ExampleError, int>.binding((_) {
+  ///   final int value = canThrowAnError();
+  ///   return value;
   /// });
   ///
   /// // DO
   /// ExampleError toExampleError(Object e, StackTrace st) { ... }
   ///
-  /// Either<ExampleError, int> result =
-  ///     Either<ExampleError, int>.binding((effect) {
-  ///   int value = Either<ExampleError, int>.catchError(
+  /// final result = Either<ExampleError, int>.binding((effect) {
+  ///   final int value = Either<ExampleError, int>.catchError(
   ///     toExampleError,
-  ///     canThrowAnError
+  ///     canThrowAnError,
   ///   ).bind(effect);
+  ///   return value;
   /// });
   /// ```
   factory Either.binding(
@@ -257,11 +256,10 @@ sealed class Either<L, R> {
   /// Future<Either<ExampleError, int>> provideY() { ... }
   /// Future<Either<ExampleError, int>> provideZ(int x, int y) { ... }
   ///
-  /// Future<Either<ExampleError, int>> result =
-  ///     Either.futureBinding<ExampleError, int>((effect) async {
-  ///   int x = provideX().bind(effect);
-  ///   int y = await effect.bindFuture(provideY());
-  ///   int z = await provideZ(x, y).bind(effect);
+  /// final result = Either.futureBinding<ExampleError, int>((effect) async {
+  ///   final int x = provideX().bind(effect);
+  ///   final int y = await effect.bindFuture(provideY());
+  ///   final int z = await provideZ(x, y).bind(effect);
   ///   return z;
   /// });
   /// ```
@@ -280,32 +278,30 @@ sealed class Either<L, R> {
   /// Future<int> errorFuture = Future.error(Exception());
   ///
   /// // DON'T
-  /// Future<Either<ExampleError, int>> result =
-  ///     Either.futureBinding<ExampleError, int>((effect) async {
-  ///   int value1 = canThrowAnError();                // DON'T
-  ///   int value2 = await canReturnAnErrorFuture();   // DON'T
-  ///   int value3 = await errorFuture;                // DON'T
+  /// final badResult = Either.futureBinding<ExampleError, int>((_) async {
+  ///   final int value1 = canThrowAnError();                // DON'T
+  ///   final int value2 = await canReturnAnErrorFuture();   // DON'T
+  ///   final int value3 = await errorFuture;                // DON'T
   ///   return value1 + value2 + value3;
   /// });
   ///
   /// // DO
   /// ExampleError toExampleError(Object e, StackTrace st) { ... }
   ///
-  /// Future<Either<ExampleError, int>> result =
-  ///     Either.futureBinding<ExampleError, int>((effect) async {
-  ///   int value1 = Either<ExampleError, int>.catchError(
+  /// final result = Either.futureBinding<ExampleError, int>((effect) async {
+  ///   final int value1 = Either<ExampleError, int>.catchError(
   ///     toExampleError,
-  ///     canThrowAnError
+  ///     canThrowAnError,
   ///   ).bind(effect);
   ///
-  ///   int value2 = await Either.catchFutureError<ExampleError, int>(
+  ///   final int value2 = await Either.catchFutureError<ExampleError, int>(
   ///     toExampleError,
-  ///     canReturnAnErrorFuture
+  ///     canReturnAnErrorFuture,
   ///   ).bind(effect);
   ///
-  ///   int value3 = await Either.catchFutureError<ExampleError, int>(
+  ///   final int value3 = await Either.catchFutureError<ExampleError, int>(
   ///     toExampleError,
-  ///     () => errorFuture
+  ///     () => errorFuture,
   ///   ).bind(effect);
   ///
   ///   return value1 + value2 + value3;

--- a/lib/src/dart_either.dart
+++ b/lib/src/dart_either.dart
@@ -125,13 +125,17 @@ sealed class Either<L, R> {
   /// `computation expressions` in `F#`, and `for comprehension` in `Scala`).
   /// This is only syntactic sugar that disguises a monadic pipeline as a code block.
   ///
-  /// Calls the specified function [block] with [EitherEffect] as its parameter and returns its [Either].
+  /// Calls [block] with a scope-bound [EitherEffect] and returns its [Either].
   ///
-  /// When inside a [Either.binding] block, calling the [EitherEffect.bind] function will attempt to unwrap the [Either]
-  /// and locally return its [Right.value]. If the [Either] is a [Left],
-  /// the binding block will terminate with that bind and return that failed-to-bind [Left].
+  /// Inside [block], `effect.bind(either)` returns the [Right.value] of
+  /// `either`. Binding a [Left] immediately terminates this binding scope and
+  /// returns that [Left]. [BindEitherExtension.bind] provides the equivalent
+  /// `either.bind(effect)` syntax.
   ///
-  /// You can also use [BindEitherExtension.bind] instead of [EitherEffect.bind] for more convenience.
+  /// Each invocation owns a distinct scope. Nested binding scopes therefore
+  /// catch only their own short-circuit. The capability is valid only while
+  /// [block] is running; invoking a captured capability after [block] returns
+  /// throws a [StateError]. Ordinary exceptions propagate unchanged.
   ///
   /// ### Example
   /// ```dart
@@ -141,37 +145,41 @@ sealed class Either<L, R> {
   /// Either<ExampleError, int> provideY() { ... }
   /// Either<ExampleError, int> provideZ(int x, int y) { ... }
   ///
-  /// Either<ExampleError, int> result = Either<ExampleError, int>.binding((e) {
-  ///   int x = provideX().bind(e);       // or use `e.bind(provideX())`.
-  ///   int y = e.bind(provideY());       // or use `provideY().bind(e)`.
-  ///   int z = provideZ(x, y).bind(e);   // or use `e.bind(provideZ(x, y))`.
+  /// Either<ExampleError, int> result =
+  ///     Either<ExampleError, int>.binding((effect) {
+  ///   int x = provideX().bind(effect);
+  ///   int y = effect.bind(provideY());
+  ///   int z = provideZ(x, y).bind(effect);
   ///   return z;
   /// });
   /// ```
   ///
   /// ### NOTE
   /// - Do NOT catch [ControlError] in [block].
-  /// - Do NOT throw any errors inside [block].
+  /// - Do NOT store [EitherEffect] or invoke it after [block] returns.
+  /// - Errors thrown by [block] are not converted to [Left].
   /// - Use [Either.catchError], [Either.catchFutureError] or [Either.catchStreamError] to catch error,
-  ///   then use [EitherEffect.bind] to unwrap the [Either].
+  ///   then bind the resulting [Either].
   ///
   /// ```dart
   /// /// This function can throw an error.
   /// int canThrowAnError() { ... }
   ///
   /// // DON'T
-  /// Either<ExampleError, int> result = Either<ExampleError, int>.binding((e) {
+  /// Either<ExampleError, int> result =
+  ///     Either<ExampleError, int>.binding((effect) {
   ///   int value = canThrowAnError();
   /// });
   ///
   /// // DO
   /// ExampleError toExampleError(Object e, StackTrace st) { ... }
   ///
-  /// Either<ExampleError, int> result = Either<ExampleError, int>.binding((e) {
+  /// Either<ExampleError, int> result =
+  ///     Either<ExampleError, int>.binding((effect) {
   ///   int value = Either<ExampleError, int>.catchError(
   ///     toExampleError,
   ///     canThrowAnError
-  ///   ).bind(e);
+  ///   ).bind(effect);
   /// });
   /// ```
   factory Either.binding(
@@ -225,20 +233,21 @@ sealed class Either<L, R> {
   /// `computation expressions` in `F#`, and `for comprehension` in `Scala`).
   /// This is only syntactic sugar that disguises a monadic pipeline as a code block.
   ///
-  /// Calls the specified function [block] with [EitherEffect] as its parameter and returns its [Either] wrapped in a [Future].
+  /// Calls [block] with a scope-bound [EitherEffect] and returns its [Either]
+  /// wrapped in a [Future].
   ///
-  /// When inside a [Either.futureBinding] block, calling the [EitherEffect.bind] function will attempt to unwrap the [Either]
-  /// and locally return its [Right.value]. If the [Either] is a [Left],
-  /// the binding block will terminate with that bind and return that failed-to-bind [Left].
+  /// Inside [block], `effect.bind(either)` returns the [Right.value] of
+  /// `either`. Binding a [Left] immediately terminates this binding scope and
+  /// completes the returned future with that [Left].
   ///
-  /// When inside a [Either.futureBinding] block, calling the [BindFutureEitherEffectExtension.bindFuture] function
-  /// will attempt to will attempt to unwrap the [Either] inside the [Future].
-  /// and locally return its [Right.value] wrapped in a [Future].
-  /// If the [Either] is a [Left], the binding block will terminate with that bind and return that failed-to-bind [Left].
-  /// If the [Future] completes with an error, it will not be handled.
+  /// [BindFutureEitherEffectExtension.bindFuture] and
+  /// [BindEitherFutureExtension.bind] unwrap an [Either] produced by a future.
+  /// An error from that future propagates unchanged.
   ///
-  /// You can also use [BindEitherExtension.bind] instead of [EitherEffect.bind],
-  /// [BindEitherFutureExtension.bind] instead of [BindFutureEitherEffectExtension.bindFuture] for more convenience.
+  /// Each invocation owns a distinct scope. Nested binding scopes therefore
+  /// catch only their own short-circuit. The capability remains valid through
+  /// the asynchronous work returned by [block], then closes when that work
+  /// settles. Invoking a captured capability afterward throws a [StateError].
   ///
   /// ### Example
   /// ```dart
@@ -248,20 +257,21 @@ sealed class Either<L, R> {
   /// Future<Either<ExampleError, int>> provideY() { ... }
   /// Future<Either<ExampleError, int>> provideZ(int x, int y) { ... }
   ///
-  /// Future<Either<ExampleError, int>> result = Either.futureBinding<ExampleError, int>((e) async {
-  ///   int x = provideX().bind(e);                   // or use `e.bind(provideX())`.
-  ///   int y = await e.bindFuture(provideY());       // or use `await provideY().bind(e)`.
-  ///   int z = await provideZ(x, y).bind(e);         // or use `await e.bindFuture(provideZ(x, y))`.
+  /// Future<Either<ExampleError, int>> result =
+  ///     Either.futureBinding<ExampleError, int>((effect) async {
+  ///   int x = provideX().bind(effect);
+  ///   int y = await effect.bindFuture(provideY());
+  ///   int z = await provideZ(x, y).bind(effect);
   ///   return z;
   /// });
   /// ```
   ///
   /// ### NOTE
   /// - Do NOT catch [ControlError] in [block].
-  /// - Do NOT throw any errors inside [block].
-  /// - When using [BindFutureEitherEffectExtension.bindFuture], if the [Future] completes with an error, it will not be handled.
+  /// - Do NOT store [EitherEffect] or invoke it after the returned future settles.
+  /// - Errors thrown by [block], or emitted by a bound future, are not converted to [Left].
   /// - Use [Either.catchError], [Either.catchFutureError] or [Either.catchStreamError] to catch error,
-  ///   then use [EitherEffect.bind] and [BindFutureEitherEffectExtension.bindFuture] to unwrap the [Either].
+  ///   then bind the resulting [Either].
   ///
   /// ```dart
   /// /// This function can throw an error.
@@ -270,7 +280,8 @@ sealed class Either<L, R> {
   /// Future<int> errorFuture = Future.error(Exception());
   ///
   /// // DON'T
-  /// Future<Either<ExampleError, int>> result = Either.futureBinding<ExampleError, int>((e) async {
+  /// Future<Either<ExampleError, int>> result =
+  ///     Either.futureBinding<ExampleError, int>((effect) async {
   ///   int value1 = canThrowAnError();                // DON'T
   ///   int value2 = await canReturnAnErrorFuture();   // DON'T
   ///   int value3 = await errorFuture;                // DON'T
@@ -280,21 +291,22 @@ sealed class Either<L, R> {
   /// // DO
   /// ExampleError toExampleError(Object e, StackTrace st) { ... }
   ///
-  /// Future<Either<ExampleError, int>> result = Either.futureBinding<ExampleError, int>((e) async {
+  /// Future<Either<ExampleError, int>> result =
+  ///     Either.futureBinding<ExampleError, int>((effect) async {
   ///   int value1 = Either<ExampleError, int>.catchError(
   ///     toExampleError,
   ///     canThrowAnError
-  ///   ).bind(e);
+  ///   ).bind(effect);
   ///
   ///   int value2 = await Either.catchFutureError<ExampleError, int>(
   ///     toExampleError,
   ///     canReturnAnErrorFuture
-  ///   ).bind(e);
+  ///   ).bind(effect);
   ///
   ///   int value3 = await Either.catchFutureError<ExampleError, int>(
   ///     toExampleError,
   ///     () => errorFuture
-  ///   ).bind(e);
+  ///   ).bind(effect);
   ///
   ///   return value1 + value2 + value3;
   /// });
@@ -1041,14 +1053,41 @@ final class _MonadComprehensions {
   const _MonadComprehensions();
 }
 
-/// TODO
+/// A scope-bound capability for binding [Either] values with the same [L].
+///
+/// The generic `bind` function returns an [Either]'s [Right.value]. Binding a
+/// [Left] short-circuits the surrounding [Either.binding] or
+/// [Either.futureBinding] scope with that left value.
+///
+/// Obtain a library-managed capability from the binding callback. A capability
+/// supplied by [Either.binding] or [Either.futureBinding] is valid only for
+/// that callback's lifetime, including asynchronous work returned by
+/// [Either.futureBinding]. Invoking it after its scope has completed throws a
+/// [StateError].
+///
+/// `EitherEffect` is contravariant in [L]: an effect accepting `num` errors can
+/// be used where one accepting only `int` errors is required, while the unsafe
+/// opposite assignment is rejected at compile time.
+///
+/// ### Example
+/// ```dart
+/// final result = Either<String, int>.binding((effect) {
+///   final value = effect.bind(Either<String, int>.right(1));
+///   return value + 1;
+/// }); // Right(2)
+/// ```
 @monadComprehensions
 typedef EitherEffect<L> = ({
   R Function<R>(Either<L, R> either) bind,
 });
 
-/// Error thrown by [EitherEffect].
-/// Must not be caught.
+/// Internal control-flow signal raised when [EitherEffect] binds a [Left].
+///
+/// [Either.binding] and [Either.futureBinding] catch only signals belonging to
+/// their own scope. User code must not catch this error. If a block swallows
+/// its scope's signal and then completes normally, the binding scope fails with
+/// a [StateError].
+///
 /// Cannot implement or extend this class.
 final class ControlError<T> extends Error {
   final _Token _token;
@@ -1097,10 +1136,13 @@ final class _BindingScope<L> {
           throw StateError('EitherEffect was used outside its binding scope.');
         }
 
-        return either.getOrHandle((v) {
-          _phase = _BindingPhase.raised;
-          throw ControlError<L>._(v, _token);
-        });
+        switch (either) {
+          case Left(value: final value):
+            _phase = _BindingPhase.raised;
+            throw ControlError<L>._(value, _token);
+          case Right(value: final value):
+            return value;
+        }
       }
     );
   }

--- a/test/dart_either_test.dart
+++ b/test/dart_either_test.dart
@@ -1313,27 +1313,6 @@ void main() {
       );
     });
 
-    test('Nullable.bind', () {
-      expect(
-        Either<String, int>.binding((effect) {
-          // ignore: unnecessary_nullable_for_final_variable_declarations
-          final int? nullable = 2;
-          final int v = nullable.bind(effect, () => 'Error'); // passed
-          return v + 1;
-        }),
-        Right<String, int>(3),
-      );
-
-      expect(
-        Either<String, int>.binding((effect) {
-          final int? nullable = null;
-          final int v = nullable.bind(effect, () => 'Error'); // failed
-          return v + 1;
-        }),
-        Left<String, int>('Error'),
-      );
-    });
-
     group('Future<Either<L, R>>.thenFlatMapEither', () {
       //
       // Right

--- a/test/dart_either_test.dart
+++ b/test/dart_either_test.dart
@@ -1313,6 +1313,27 @@ void main() {
       );
     });
 
+    test('Nullable.bind', () {
+      expect(
+        Either<String, int>.binding((effect) {
+          // ignore: unnecessary_nullable_for_final_variable_declarations
+          final int? nullable = 2;
+          final int v = nullable.bind(effect, () => 'Error'); // passed
+          return v + 1;
+        }),
+        Right<String, int>(3),
+      );
+
+      expect(
+        Either<String, int>.binding((effect) {
+          final int? nullable = null;
+          final int v = nullable.bind(effect, () => 'Error'); // failed
+          return v + 1;
+        }),
+        Left<String, int>('Error'),
+      );
+    });
+
     group('Future<Either<L, R>>.thenFlatMapEither', () {
       //
       // Right

--- a/test/dart_either_test.dart
+++ b/test/dart_either_test.dart
@@ -357,7 +357,7 @@ void main() {
             // 1 success bind (async) + 1 failure bind (sync) - with async modifier
             expect(
               Either.futureBinding<Object, int>((e) async {
-                final a = await Future.delayed(
+                final a = await Future<Either<Object, int>>.delayed(
                   const Duration(milliseconds: 100),
                   () => Either<Object, int>.right(1),
                 ).bind(e);
@@ -377,7 +377,7 @@ void main() {
             // 1 success bind (async) + 1 failure bind (async) - with async modifier
             expect(
               Either.futureBinding<Object, int>((e) async {
-                final a = await Future.delayed(
+                final a = await Future<Either<Object, int>>.delayed(
                   const Duration(milliseconds: 100),
                   () => Either<Object, int>.right(1),
                 ).bind(e);
@@ -627,7 +627,7 @@ void main() {
           final result = await Either.parSequenceN<String, int>(
             functions: delays.map(
               (delay) => () async {
-                await Future.delayed(Duration(milliseconds: delay));
+                await Future<void>.delayed(Duration(milliseconds: delay));
                 values.add(delay);
                 return Either<String, int>.right(delay);
               },
@@ -646,7 +646,7 @@ void main() {
           final result = await Either.parSequenceN<String, int>(
             functions: delays.map(
               (delay) => () async {
-                await Future.delayed(Duration(milliseconds: delay));
+                await Future<void>.delayed(Duration(milliseconds: delay));
                 values.add(delay);
                 return Either<String, int>.right(delay);
               },
@@ -666,7 +666,8 @@ void main() {
           final result = await Either.parSequenceN<String, int>(
             functions: items.map(
               (index) => () async {
-                await Future.delayed(Duration(milliseconds: (index + 1) * 50));
+                await Future<void>.delayed(
+                    Duration(milliseconds: (index + 1) * 50));
                 values.add(index);
                 return index < anchor
                     ? Either<String, int>.right(index)
@@ -688,7 +689,7 @@ void main() {
             functions: delays.map(
               (delay) => () async {
                 activeCount.add(1);
-                await Future.delayed(Duration(milliseconds: delay));
+                await Future<void>.delayed(Duration(milliseconds: delay));
                 activeCount.add(-1);
                 return Either<String, int>.right(delay);
               },
@@ -715,7 +716,7 @@ void main() {
           final result = await Either.parTraverseN<String, int, int>(
             values: ids,
             mapper: (id) => () async {
-              await Future.delayed(Duration(milliseconds: id * 50));
+              await Future<void>.delayed(Duration(milliseconds: id * 50));
               values.add(id);
               return Either<String, int>.right(id * factor);
             },
@@ -738,7 +739,7 @@ void main() {
           final result = await Either.parTraverseN<String, int, int>(
             values: ids,
             mapper: (id) => () async {
-              await Future.delayed(Duration(milliseconds: id * 50));
+              await Future<void>.delayed(Duration(milliseconds: id * 50));
               values.add(id);
               return id < anchor
                   ? Either<String, int>.right(id * factor)

--- a/test/either_effect_test.dart
+++ b/test/either_effect_test.dart
@@ -34,18 +34,9 @@ void main() {
     });
 
     test('rejects unsafe widening during static analysis', () async {
-      final packageConfig = await Isolate.packageConfig;
-      expect(packageConfig, isNotNull, reason: 'Package config is required.');
-
-      final temporaryDirectory =
-          await Directory.systemTemp.createTemp('dart_either_variance_');
-      addTearDown(() => temporaryDirectory.delete(recursive: true));
-
-      final fixture = File(
-        '${temporaryDirectory.path}${Platform.pathSeparator}'
-        'unsafe_either_effect_widen.dart',
-      );
-      await fixture.writeAsString('''
+      final analysis = await _analyzeConsumerFixture(
+        fileName: 'unsafe_either_effect_widen.dart',
+        source: '''
 import 'package:dart_either/dart_either.dart';
 
 void reproduce() {
@@ -54,28 +45,41 @@ void reproduce() {
     return widened.bind(Either<num, String>.left(1.5));
   });
 }
-''');
-
-      final result = await Process.run(
-        Platform.resolvedExecutable,
-        <String>[
-          '--packages=${packageConfig!.toFilePath()}',
-          'analyze',
-          '--format=machine',
-          fixture.path,
-        ],
-        environment: <String, String>{
-          ...Platform.environment,
-          'CI': 'true',
-        },
+''',
       );
-      final analyzerOutput = '${result.stdout}\n${result.stderr}';
 
-      expect(result.exitCode, isNot(0), reason: analyzerOutput);
+      expect(analysis.exitCode, isNot(0), reason: analysis.output);
       expect(
-        analyzerOutput,
+        analysis.output,
         contains('ERROR|COMPILE_TIME_ERROR|INVALID_ASSIGNMENT|'),
-        reason: analyzerOutput,
+        reason: analysis.output,
+      );
+    });
+
+    test('rejects independent record construction during static analysis',
+        () async {
+      final analysis = await _analyzeConsumerFixture(
+        fileName: 'independent_either_effect_construction.dart',
+        source: '''
+import 'package:dart_either/dart_either.dart';
+
+void reproduce() {
+  final EitherEffect<String> effect = (
+    bind: <R>(Either<String, R> either) => switch (either) {
+      Left(value: final value) => throw StateError(value),
+      Right(value: final value) => value,
+    },
+  );
+  effect.bind(Either<String, int>.right(1));
+}
+''',
+      );
+
+      expect(analysis.exitCode, isNot(0), reason: analysis.output);
+      expect(
+        analysis.output,
+        contains('ERROR|COMPILE_TIME_ERROR|INVALID_ASSIGNMENT|'),
+        reason: analysis.output,
       );
     });
 
@@ -188,4 +192,40 @@ void reproduce() {
       );
     });
   });
+}
+
+Future<({int exitCode, String output})> _analyzeConsumerFixture({
+  required String fileName,
+  required String source,
+}) async {
+  final packageConfig = await Isolate.packageConfig;
+  expect(packageConfig, isNotNull, reason: 'Package config is required.');
+
+  final temporaryDirectory =
+      await Directory.systemTemp.createTemp('dart_either_analyzer_');
+  addTearDown(() => temporaryDirectory.delete(recursive: true));
+
+  final fixture = File(
+    '${temporaryDirectory.path}${Platform.pathSeparator}$fileName',
+  );
+  await fixture.writeAsString(source);
+
+  final result = await Process.run(
+    Platform.resolvedExecutable,
+    <String>[
+      '--packages=${packageConfig!.toFilePath()}',
+      'analyze',
+      '--format=machine',
+      fixture.path,
+    ],
+    environment: <String, String>{
+      ...Platform.environment,
+      'CI': 'true',
+    },
+  );
+
+  return (
+    exitCode: result.exitCode,
+    output: '${result.stdout}\n${result.stderr}',
+  );
 }

--- a/test/either_effect_test.dart
+++ b/test/either_effect_test.dart
@@ -1,0 +1,191 @@
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:dart_either/dart_either.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('EitherEffect', () {
+    test('supports safe contravariant narrowing', () {
+      final result = Either<num, String>.binding((effect) {
+        final EitherEffect<int> narrowed = effect;
+        return narrowed.bind(Either<int, String>.left(1));
+      });
+
+      expect(result, Left<num, String>(1));
+    });
+
+    test('binds widened Either runtime subtypes without a type error', () {
+      final Either<int, String> widenedLeft = const Left<int, Never>(1);
+      final Either<String, num> widenedRight = const Right<Never, int>(2);
+
+      expect(
+        Either<int, String>.binding(
+          (effect) => effect.bind(widenedLeft),
+        ),
+        Left<int, String>(1),
+      );
+      expect(
+        Either<String, num>.binding(
+          (effect) => effect.bind(widenedRight),
+        ),
+        Right<String, num>(2),
+      );
+    });
+
+    test('rejects unsafe widening during static analysis', () async {
+      final packageConfig = await Isolate.packageConfig;
+      expect(packageConfig, isNotNull, reason: 'Package config is required.');
+
+      final temporaryDirectory =
+          await Directory.systemTemp.createTemp('dart_either_variance_');
+      addTearDown(() => temporaryDirectory.delete(recursive: true));
+
+      final fixture = File(
+        '${temporaryDirectory.path}${Platform.pathSeparator}'
+        'unsafe_either_effect_widen.dart',
+      );
+      await fixture.writeAsString('''
+import 'package:dart_either/dart_either.dart';
+
+void reproduce() {
+  Either<int, String>.binding((effect) {
+    final EitherEffect<num> widened = effect;
+    return widened.bind(Either<num, String>.left(1.5));
+  });
+}
+''');
+
+      final result = await Process.run(
+        Platform.resolvedExecutable,
+        <String>[
+          '--packages=${packageConfig!.toFilePath()}',
+          'analyze',
+          '--format=machine',
+          fixture.path,
+        ],
+        environment: <String, String>{
+          ...Platform.environment,
+          'CI': 'true',
+        },
+      );
+      final analyzerOutput = '${result.stdout}\n${result.stderr}';
+
+      expect(result.exitCode, isNot(0), reason: analyzerOutput);
+      expect(
+        analyzerOutput,
+        contains('ERROR|COMPILE_TIME_ERROR|INVALID_ASSIGNMENT|'),
+        reason: analyzerOutput,
+      );
+    });
+
+    test('nested binding catches only its own short-circuit', () {
+      final result = Either<String, int>.binding((outerEffect) {
+        return Either<String, int>.binding((innerEffect) {
+          return outerEffect.bind(Either<String, int>.left('outer'));
+        }).bind(outerEffect);
+      });
+
+      expect(result, Left<String, int>('outer'));
+    });
+
+    test('nested futureBinding catches only its own short-circuit', () async {
+      final result = await Either.futureBinding<String, int>(
+        (outerEffect) async {
+          final inner = await Either.futureBinding<String, int>(
+            (innerEffect) async {
+              await Future<void>.delayed(Duration.zero);
+              return outerEffect.bind(Either<String, int>.left('outer'));
+            },
+          );
+          return inner.bind(outerEffect);
+        },
+      );
+
+      expect(result, Left<String, int>('outer'));
+    });
+
+    test('rejects a captured capability after binding returns', () {
+      late EitherEffect<String> captured;
+
+      final result = Either<String, int>.binding((effect) {
+        captured = effect;
+        return 1;
+      });
+
+      expect(result, Right<String, int>(1));
+      expect(
+        () => captured.bind(Either<String, int>.right(2)),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            'EitherEffect was used outside its binding scope.',
+          ),
+        ),
+      );
+    });
+
+    test('rejects a captured capability after futureBinding settles', () async {
+      late EitherEffect<String> captured;
+
+      final result = await Either.futureBinding<String, int>((effect) async {
+        captured = effect;
+        await Future<void>.delayed(Duration.zero);
+        return 1;
+      });
+
+      expect(result, Right<String, int>(1));
+      expect(
+        () => captured.bind(Either<String, int>.right(2)),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            'EitherEffect was used outside its binding scope.',
+          ),
+        ),
+      );
+    });
+
+    test('rejects an intercepted binding short-circuit', () {
+      expect(
+        () => Either<String, int>.binding((effect) {
+          try {
+            effect.bind(Either<String, int>.left('failure'));
+          } on ControlError<String> catch (error) {
+            expect(error, isA<ControlError<String>>());
+          }
+          return 1;
+        }),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            'Binding short-circuit was intercepted.',
+          ),
+        ),
+      );
+    });
+
+    test('rejects an intercepted futureBinding short-circuit', () async {
+      await expectLater(
+        Either.futureBinding<String, int>((effect) async {
+          try {
+            effect.bind(Either<String, int>.left('failure'));
+          } on ControlError<String> catch (error) {
+            expect(error, isA<ControlError<String>>());
+          }
+          return 1;
+        }),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            'Binding short-circuit was intercepted.',
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/test/either_effect_test.dart
+++ b/test/either_effect_test.dart
@@ -56,21 +56,16 @@ void reproduce() {
       );
     });
 
-    test('rejects independent record construction during static analysis',
+    test('rejects construction through the public typedef outside the library',
         () async {
       final analysis = await _analyzeConsumerFixture(
-        fileName: 'independent_either_effect_construction.dart',
+        fileName: 'external_either_effect_construction.dart',
         source: '''
 import 'package:dart_either/dart_either.dart';
 
 void reproduce() {
-  final EitherEffect<String> effect = (
-    bind: <R>(Either<String, R> either) => switch (either) {
-      Left(value: final value) => throw StateError(value),
-      Right(value: final value) => value,
-    },
-  );
-  effect.bind(Either<String, int>.right(1));
+  final effect = EitherEffect<String>();
+  print(effect);
 }
 ''',
       );
@@ -78,7 +73,9 @@ void reproduce() {
       expect(analysis.exitCode, isNot(0), reason: analysis.output);
       expect(
         analysis.output,
-        contains('ERROR|COMPILE_TIME_ERROR|INVALID_ASSIGNMENT|'),
+        contains(
+          'ERROR|COMPILE_TIME_ERROR|NEW_WITH_UNDEFINED_CONSTRUCTOR_DEFAULT|',
+        ),
         reason: analysis.output,
       );
     });


### PR DESCRIPTION

## Summary

Fix the `EitherEffect<L>` covariance hole without changing the supported binding UX.

- Represent `EitherEffect<L>` as an opaque, contravariant capability backed by a library-private final binding scope.
- Preserve `effect.bind(either)`, `either.bind(effect)`, `eitherFuture.bind(effect)`, `bindFuture`, `ensure`, and `ensureNotNull`.
- Keep nested binding scopes isolated by token identity.
- Revoke captured capabilities after their sync or async scope settles.
- Detect intercepted short-circuit signals instead of incorrectly producing `Right`.
- Prevent error-catching APIs from converting internal binding control flow into `Left`.
- Document the variance proof, lifecycle contract, compatibility boundary, and rejected alternatives.
- Enable stricter casts, inference, and raw-type analysis.

## Type safety

The previous nominal `EitherEffect<L>` was covariant even though `bind` consumed `Either<L, R>`. Dart therefore accepted unsafe widening that could fail with a runtime `TypeError`.

The new representation uses a contravariant phantom marker:

```dart
typedef EitherEffect<L> = _BindingScope<Never Function(L)>;
```

This provides:

- safe `EitherEffect<num>` → `EitherEffect<int>` narrowing;
- compile-time rejection of unsafe `EitherEffect<int>` → `EitherEffect<num>` widening;
- no externally replaceable `bind` implementation;
- no public constructor or external implementation;
- direct binding of widened `Left<L, Never>` and `Right<Never, R>` values without a virtual-method type check.

## Compatibility

This change targets a `2.x.y` release.

Supported source usage and runtime behavior remain unchanged: callers obtain an `EitherEffect` from `Either.binding` or `Either.futureBinding` and use the existing binding syntax inside that scope.

Direct construction, implementation, destructuring, replacement of binding behavior, or invocation after the owning scope settles is outside the supported contract and does not require a migration path.

## Documentation

- Update the README API list and binding examples.
- Correct `ensureNotNull` documentation to require using its returned non-null value.
- Add the binding domain language and variance-safety guide.
- Record the final design and alternatives in ADR 0001.
- Document the `2.x.y` compatibility boundary.

## Test plan

- [x] `dart format --set-exit-if-changed .`
- [x] `dart analyze`
- [x] `dart test test/either_effect_test.dart --chain-stack-traces`
- [x] `dart test --coverage=./coverage --chain-stack-traces`
- [x] Verify unsafe widening fails static analysis.
- [x] Verify `EitherEffect<L>()` cannot be constructed outside the library.
- [x] Verify widened runtime `Left` and `Right` values bind without `TypeError`.
- [x] Verify nested sync/async token isolation.
- [x] Verify captured capabilities are rejected after scope completion.
- [x] Verify intercepted short-circuit signals fail with `StateError`.

Full suite: 123 tests passed.
